### PR TITLE
fix: skip first bot At component in group image generation

### DIFF
--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -183,6 +183,9 @@ class ImageProcessor:
         if not event.message_obj or not event.message_obj.message:
             return images_data
 
+        bot_self_id = str(event.get_self_id()) if hasattr(event, "get_self_id") else ""
+        first_at_bot_skipped = False
+
         for component in event.message_obj.message:
             try:
                 if isinstance(component, Comp.Image):
@@ -199,9 +202,12 @@ class ImageProcessor:
                                 if url and (data := await self.download_image(url)):
                                     images_data.append(data)
                 elif isinstance(component, Comp.At):
-                    # 处理 @ 用户的头像，跳过机器人自身
-                    bot_self_id = str(event.get_self_id()) if hasattr(event, "get_self_id") else ""
-                    if hasattr(component, "qq") and component.qq != "all" and str(component.qq) != bot_self_id:
+                    # 处理 @ 用户的头像
+                    # 跳过消息中第一个 @机器人
+                    if hasattr(component, "qq") and component.qq != "all":
+                        if str(component.qq) == bot_self_id and not first_at_bot_skipped:
+                            first_at_bot_skipped = True
+                            continue
                         uid = str(component.qq)
                         if uid in avatar_user_ids:
                             continue

--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -199,8 +199,9 @@ class ImageProcessor:
                                 if url and (data := await self.download_image(url)):
                                     images_data.append(data)
                 elif isinstance(component, Comp.At):
-                    # 处理 @ 用户的头像
-                    if hasattr(component, "qq") and component.qq != "all":
+                    # 处理 @ 用户的头像，跳过机器人自身
+                    bot_self_id = str(event.get_self_id()) if hasattr(event, "get_self_id") else ""
+                    if hasattr(component, "qq") and component.qq != "all" and str(component.qq) != bot_self_id:
                         uid = str(component.qq)
                         if uid in avatar_user_ids:
                             continue


### PR DESCRIPTION
## 问题

在群聊中使用生图指令时，消息里的 @机器人 组件会被识别为参考图来源，导致机器人自己的头像被加入参考图列表，影响生成结果。

## 修复

在 `fetch_images_from_event` 处理 At 组件时，跳过机器人自身的 QQ 号。

fix #15 related #13