### PR TITLE
Add Agnes AI image provider adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | `jimeng2api`          | jimeng-api `/v1/images/generations`、`/v1/images/compositions` |   ✅    |   ✅    |    ✅     | 适用于 [iptag/jimeng-api](https://github.com/iptag/jimeng-api)。                                |
 | `grok`                | xAI Images API `/v1/images/generations`、`/v1/images/edits`    |   ✅    |   ✅    |    ✅     | Grok / xAI 图像生成接口。                                                                       |
 | `siliconflow_adapter` | SiliconFlow Images API `/v1/images/generations`                |   ✅    |   ✅    |    ✅     | 支持 Kolors、Qwen-Image、Qwen-Image-Edit、Z-Image；多参考图映射到 `image`、`image2`、`image3`。 |
+| `agnes_ai`            | Agnes AI Images API `/v1/images/generations`                   |   ✅    |   ✅    |    ✅     | 支持 `agnes-image-2.0-flash` 和 `agnes-image-2.1-flash`；宽高比会在插件内映射为官方 `size` 字段，不会发送 `aspect_ratio` 字段；2.0 图生图会自动附加 `tags: ["img2img"]`，参考图通过 `extra_body.image` 发送。 |
 
 ## 配置
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -625,6 +625,97 @@
           }
         }
       },
+      "agnes_ai": {
+        "name": "Agnes AI 接口",
+        "hint": "调用 Agnes AI 图像生成接口，支持文生图和通过 extra_body.image 的图生图；宽高比会在插件内映射为官方 size 字段，不会发送 aspect_ratio 字段。",
+        "display_item": "name",
+        "hide_hint_in_list": true,
+        "items": {
+          "name": {
+            "description": "供应商名称",
+            "hint": "用于显示和模型选择；格式为“供应商名称/模型名称”。",
+            "type": "string",
+            "default": ""
+          },
+          "base_url": {
+            "description": "API Base URL",
+            "hint": "可选。留空使用 https://apihub.agnes-ai.com；也可填写兼容的 API Base URL。",
+            "type": "string",
+            "default": ""
+          },
+          "proxy": {
+            "description": "代理地址",
+            "hint": "可选，示例：http://127.0.0.1:7890。",
+            "type": "string",
+            "default": ""
+          },
+          "api_keys": {
+            "description": "API 密钥",
+            "hint": "填写该供应商的 API Key 或 Token；可配置多个用于轮换。",
+            "type": "list",
+            "default": []
+          },
+          "available_models": {
+            "description": "可用模型列表",
+            "hint": "用于 /生图模型 命令切换；请按账号实际可用模型维护。",
+            "type": "list",
+            "default": [
+              "agnes-image-2.0-flash",
+              "agnes-image-2.1-flash"
+            ]
+          },
+          "capability_options": {
+            "description": "模型能力",
+            "hint": "按当前模型实际能力勾选；Agnes 的“宽高比”仅表示插件会映射为官方 size 字段，不会发送 aspect_ratio 字段。",
+            "type": "list",
+            "options": [
+              "文生图",
+              "图生图",
+              "宽高比",
+              "分辨率"
+            ],
+            "default": [
+              "文生图",
+              "图生图",
+              "宽高比",
+              "分辨率"
+            ]
+          },
+          "timeout": {
+            "description": "超时时间覆盖（秒）",
+            "hint": "填 0 表示使用全局超时时间。",
+            "type": "int",
+            "slider": {
+              "min": 0,
+              "max": 600,
+              "step": 10
+            },
+            "default": 0
+          },
+          "max_retry_attempts": {
+            "description": "重试次数覆盖",
+            "hint": "填 0 表示使用全局重试次数。",
+            "type": "int",
+            "slider": {
+              "min": 0,
+              "max": 10,
+              "step": 1
+            },
+            "default": 0
+          },
+          "seed": {
+            "description": "随机种子",
+            "hint": "可选；Agnes Image 2.0 Flash 支持。填 0 表示不发送 seed。",
+            "type": "int",
+            "slider": {
+              "min": 0,
+              "max": 2147483647,
+              "step": 1
+            },
+            "default": 0
+          }
+        }
+      },
       "jimeng2api": {
         "name": "即梦接口",
         "hint": "调用 iptag/jimeng-api 项目的图像生成接口。",

--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -3,6 +3,7 @@ Adapter module for image generation plugin
 图像生成插件的适配器模块
 """
 
+from .agnes_ai_adapter import AgnesAIAdapter
 from .gemini_adapter import GeminiAdapter
 from .gemini_openai_adapter import GeminiOpenAIAdapter
 from .gitee_ai_adapter import GiteeAIAdapter
@@ -13,6 +14,7 @@ from .siliconflow_adapter import SiliconFlowAdapter
 from .volcengine_ark_adapter import VolcengineArkAdapter
 
 __all__ = [
+    "AgnesAIAdapter",
     "GeminiAdapter",
     "GeminiOpenAIAdapter",
     "GiteeAIAdapter",

--- a/adapter/agnes_ai_adapter.py
+++ b/adapter/agnes_ai_adapter.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any
+
+from astrbot.api import logger
+
+from ..core.base_adapter import BaseImageAdapter
+from ..core.constants import RESOLUTION_1K_MAP, RESOLUTION_2K_MAP, UNSPECIFIED_OPTION
+from ..core.logging_utils import (
+    safe_log_error_body,
+    safe_log_mapping,
+    safe_log_url,
+)
+from ..core.types import GenerationRequest, ImageCapability, ImageData
+
+
+class AgnesAIAdapter(BaseImageAdapter):
+    """Agnes AI 图像生成适配器。"""
+
+    DEFAULT_BASE_URL = "https://apihub.agnes-ai.com"
+    DEFAULT_MODEL = "agnes-image-2.1-flash"
+
+    EXTRA_1K_SIZE_MAP = {
+        "4:5": "832x1024",
+        "5:4": "1024x832",
+        "21:9": "1024x448",
+    }
+    EXTRA_2K_SIZE_MAP = {
+        "4:5": "1632x2048",
+        "5:4": "2048x1632",
+        "21:9": "2048x864",
+    }
+
+    def get_capabilities(self) -> ImageCapability:
+        """获取适配器支持的功能。"""
+        configured = self._get_configured_capabilities()
+        defaults = (
+            ImageCapability.TEXT_TO_IMAGE
+            | ImageCapability.IMAGE_TO_IMAGE
+            | ImageCapability.ASPECT_RATIO
+            | ImageCapability.RESOLUTION
+        )
+        if configured is ImageCapability.NONE:
+            return defaults
+        return configured | ImageCapability.ASPECT_RATIO
+
+    async def _generate_once(
+        self, request: GenerationRequest
+    ) -> tuple[list[bytes] | None, str | None]:
+        """执行单次生图请求。"""
+        start_time = time.time()
+        prefix = self._get_log_prefix(request.task_id)
+        payload = self._build_payload(request)
+        url = self._endpoint_url()
+        headers = {
+            "Authorization": f"Bearer {self._get_current_api_key()}",
+            "Content-Type": "application/json",
+        }
+
+        image_count = len(payload.get("extra_body", {}).get("image", []))
+        logger.debug(
+            f"{prefix} 请求 URL: {safe_log_url(url)}, Payload 字段: {list(payload.keys())}, "
+            f"参考图={image_count}张"
+        )
+
+        try:
+            async with self._get_session().post(
+                url,
+                json=payload,
+                headers=headers,
+                proxy=self.proxy,
+                timeout=self._get_timeout(),
+            ) as resp:
+                duration = time.time() - start_time
+                if resp.status != 200:
+                    error_text = await resp.text()
+                    logger.error(
+                        f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
+                    )
+                    return None, f"API 错误 ({resp.status})"
+
+                data = await resp.json()
+                logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
+                return await self._extract_images(data, request.task_id)
+        except Exception as e:  # noqa: BLE001
+            duration = time.time() - start_time
+            logger.error(f"{prefix} 请求异常 (耗时: {duration:.2f}s): {e}")
+            return None, str(e)
+
+    def _endpoint_url(self) -> str:
+        """构建 Agnes AI 图像生成接口地址。"""
+        base = (self.base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        suffix = "/v1/images/generations"
+        if base.endswith(suffix):
+            return base
+        if base.endswith("/v1"):
+            return f"{base}/images/generations"
+        return f"{base}{suffix}"
+
+    def _build_payload(self, request: GenerationRequest) -> dict[str, Any]:
+        """构建请求载荷。"""
+        payload: dict[str, Any] = {
+            "model": self._model_name(),
+            "prompt": request.prompt,
+        }
+        if size := self._resolve_size(request):
+            payload["size"] = size
+        if seed := self._resolve_seed():
+            payload["seed"] = seed
+
+        extra_body: dict[str, Any] = {"response_format": "url"}
+        if request.images:
+            if self._needs_img2img_tag():
+                payload["tags"] = ["img2img"]
+            extra_body["image"] = self._build_image_refs(request.images)
+        payload["extra_body"] = extra_body
+
+        return payload
+
+    def _model_name(self) -> str:
+        """获取当前模型名称。"""
+        return self.model or self.DEFAULT_MODEL
+
+    def _needs_img2img_tag(self) -> bool:
+        """Agnes Image 2.0 Flash 的图生图请求需要显式 img2img 标签。"""
+        model_name = self._model_name().lower()
+        return "agnes-image-2.0-flash" in model_name
+
+    def _resolve_seed(self) -> int | None:
+        """解析可选随机种子；填 0 或留空表示不发送。"""
+        if not self._needs_img2img_tag():
+            return None
+        value = self.config.extra.get("seed")
+        if value in (None, "") or isinstance(value, bool):
+            return None
+        try:
+            seed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return seed if seed > 0 else None
+
+    def _resolve_size(self, request: GenerationRequest) -> str | None:
+        """按宽高比和分辨率解析 Agnes AI size 参数。"""
+        if not request.aspect_ratio or request.aspect_ratio == UNSPECIFIED_OPTION:
+            return None
+
+        aspect_ratio = request.aspect_ratio
+        resolution = (request.resolution or "").upper()
+        if resolution in ("2K", "4K"):
+            size_map = {**RESOLUTION_2K_MAP, **self.EXTRA_2K_SIZE_MAP}
+            return size_map.get(aspect_ratio, "2048x2048")
+
+        size_map = {**RESOLUTION_1K_MAP, **self.EXTRA_1K_SIZE_MAP}
+        return size_map.get(aspect_ratio, "1024x1024")
+
+    def _build_image_refs(self, images: list[ImageData]) -> list[str]:
+        """构建 Agnes AI 图生图参考图数组。
+
+        QQ 等平台给出的图片 URL 往往是需要平台侧鉴权的临时下载链接，
+        Agnes 云端无法访问；因此这里传 data URL，让参考图内容随请求一起发送。
+        """
+        refs: list[str] = []
+        for image in images:
+            if not image.data:
+                continue
+            mime_type = image.mime_type or "image/png"
+            b64_data = base64.b64encode(image.data).decode("ascii")
+            refs.append(f"data:{mime_type};base64,{b64_data}")
+        return refs
+
+    async def _extract_images(
+        self, response: dict[str, Any], task_id: str | None = None
+    ) -> tuple[list[bytes] | None, str | None]:
+        """从响应中提取图片数据。"""
+        if response_error := response.get("error"):
+            if isinstance(response_error, dict):
+                message = response_error.get("message") or response_error.get("code")
+                return None, f"API 错误: {message}"
+            return None, f"API 错误: {response_error}"
+
+        data_items = response.get("data")
+        if not isinstance(data_items, list):
+            return None, f"响应中未找到 data 字段: {safe_log_mapping(response)}"
+
+        images: list[bytes] = []
+        for item in data_items:
+            if not isinstance(item, dict):
+                continue
+
+            b64_json = item.get("b64_json")
+            if b64_json:
+                try:
+                    images.append(base64.b64decode(b64_json))
+                    continue
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"{self._get_log_prefix(task_id)} 跳过无效 b64_json 图片数据: {e}"
+                    )
+
+            image_url = item.get("url") or item.get("image_url")
+            if isinstance(image_url, str) and image_url:
+                if image_url.startswith("data:image/"):
+                    if data := self._decode_base64_image(image_url, task_id):
+                        images.append(data)
+                elif data := await self._download_image(image_url, task_id):
+                    images.append(data)
+
+        if not images:
+            return None, "未找到有效的图片数据"
+
+        return images, None
+
+    def _decode_base64_image(
+        self, value: Any, task_id: str | None = None
+    ) -> bytes | None:
+        """解码 b64_json 或 data URL 图片。"""
+        data = str(value or "")
+        if ";base64," in data:
+            _, _, data = data.partition(";base64,")
+        try:
+            return base64.b64decode(data)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"{self._get_log_prefix(task_id)} Base64 解码失败: {exc}")
+            return None
+
+    async def _download_image(
+        self, url: str, task_id: str | None = None
+    ) -> bytes | None:
+        """下载 Agnes AI 返回的临时图片 URL。"""
+        prefix = self._get_log_prefix(task_id)
+        try:
+            async with self._get_session().get(
+                url, proxy=self.proxy, timeout=self._get_download_timeout()
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.read()
+                logger.warning(f"{prefix} 下载 Agnes AI 图片失败: HTTP {resp.status}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"{prefix} 下载 Agnes AI 图片异常: {exc}")
+        return None

--- a/core/generator.py
+++ b/core/generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from astrbot.api import logger
 
 from ..adapter import (
+    AgnesAIAdapter,
     GeminiAdapter,
     GeminiOpenAIAdapter,
     GiteeAIAdapter,
@@ -39,6 +40,7 @@ class ImageGenerator:
             AdapterType.SILICONFLOW: SiliconFlowAdapter,
             AdapterType.VOLCENGINE_ARK: VolcengineArkAdapter,
             AdapterType.GITEE_AI: GiteeAIAdapter,
+            AdapterType.AGNES_AI: AgnesAIAdapter,
             AdapterType.JIMENG2API: Jimeng2APIAdapter,
             AdapterType.GROK: GrokAdapter,
         }

--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -16,6 +16,7 @@ from astrbot.api import logger
 from astrbot.core.utils.io import download_image_by_url
 
 from .logging_utils import log_prefix, mask_sensitive, safe_log_url
+from .types import ImageData
 
 if TYPE_CHECKING:
     from astrbot.api.event import AstrMessageEvent
@@ -110,15 +111,17 @@ class ImageProcessor:
             path = path[1:]
         return os.path.normpath(path)
 
-    async def download_image(self, url: str) -> tuple[bytes, str] | None:
-        """下载或读取图片并返回二进制数据和 MIME 类型。"""
+    async def download_image(self, url: str) -> ImageData | None:
+        """下载或读取图片并返回图像数据、MIME 类型和可选来源 URL。"""
         try:
             url = url.strip()
             if not url:
                 return None
 
             data: bytes | None = None
+            source_url = url if self._is_network_url(url) else None
             if local_path := self._resolve_local_path(url):
+                source_url = None
                 with open(local_path, "rb") as f:
                     data = f.read()
             else:
@@ -141,7 +144,7 @@ class ImageProcessor:
                 return None
 
             mime = self._detect_mime_type(data)
-            return data, mime
+            return ImageData(data=data, mime_type=mime, source_url=source_url)
         except Exception as exc:
             logger.error(f"{LOG} 获取图片失败: {safe_log_url(url)} ({exc})")
         return None
@@ -215,9 +218,9 @@ class ImageProcessor:
         self,
         event: AstrMessageEvent,
         avatar_user_ids: set[str] | None = None,
-    ) -> list[tuple[bytes, str]]:
+    ) -> list[ImageData]:
         """从消息事件中提取图片（包括直接发送的图片、引用消息中的图片、被@用户的头像）。"""
-        images_data: list[tuple[bytes, str]] = []
+        images_data: list[ImageData] = []
         if avatar_user_ids is None:
             avatar_user_ids = set()
 
@@ -261,7 +264,7 @@ class ImageProcessor:
                             continue
                         avatar_user_ids.add(uid)
                         if avatar_data := await self.get_avatar(uid):
-                            images_data.append((avatar_data, "image/jpeg"))
+                            images_data.append(ImageData(data=avatar_data, mime_type="image/jpeg"))
             except Exception as e:
                 logger.error(f"{LOG} 提取消息组件图片失败: {e}", exc_info=True)
                 continue

--- a/core/public_api.py
+++ b/core/public_api.py
@@ -20,7 +20,7 @@ from .reference_collector import (
     normalize_string_items,
 )
 from .task_manager import GenerationTaskRecord
-from .types import ImageCapability
+from .types import ImageCapability, ImageData
 
 
 LOG = log_prefix("PublicAPI")
@@ -100,7 +100,7 @@ class ImageGenerationPublicAPI:
         aspect_ratio: str | None = None,
         resolution: str | None = None,
         reference_image_sources: Any = None,
-        reference_image_data: list[tuple[bytes, str]] | None = None,
+        reference_image_data: list[ImageData | tuple[bytes, str]] | None = None,
         presets: str | list[str] | None = None,
         personas: str | list[str] | None = None,
         is_admin: bool = False,
@@ -338,7 +338,7 @@ class ImageGenerationPublicAPI:
         aspect_ratio: str | None = None,
         resolution: str | None = None,
         reference_image_sources: Any = None,
-        reference_image_data: list[tuple[bytes, str]] | None = None,
+        reference_image_data: list[ImageData | tuple[bytes, str]] | None = None,
         presets: str | list[str] | None = None,
         personas: str | list[str] | None = None,
         is_admin: bool = False,
@@ -553,10 +553,10 @@ class ImageGenerationPublicAPI:
         self,
         *,
         reference_image_sources: Any,
-        reference_image_data: list[tuple[bytes, str]] | None,
+        reference_image_data: list[ImageData] | None,
         persona_images: list[tuple[str, str]],
         task_id: str,
-    ) -> list[tuple[bytes, str]]:
+    ) -> list[ImageData]:
         plugin = self._plugin
         if not plugin.generator or not plugin.generator.adapter:
             return []
@@ -571,7 +571,7 @@ class ImageGenerationPublicAPI:
                 )
             return []
 
-        images_data: list[tuple[bytes, str]] = []
+        images_data: list[ImageData] = []
         if persona_images:
             images_data.extend(
                 await collect_reference_images_from_personas(
@@ -599,9 +599,9 @@ class ImageGenerationPublicAPI:
 
     def _normalize_reference_image_data(
         self,
-        reference_image_data: list[tuple[bytes, str]] | None,
-    ) -> list[tuple[bytes, str]]:
-        images_data: list[tuple[bytes, str]] = []
+        reference_image_data: list[ImageData] | None,
+    ) -> list[ImageData]:
+        images_data: list[ImageData] = []
         max_size = self._plugin.config_manager.usage_settings.max_image_size_mb
         for item in reference_image_data or []:
             try:
@@ -617,5 +617,5 @@ class ImageGenerationPublicAPI:
             if len(data) > max_size * 1024 * 1024:
                 logger.warning(f"{LOG} 已忽略超过大小限制的二进制参考图 ({max_size}MB)")
                 continue
-            images_data.append((data, str(mime or "image/png")))
+            images_data.append(ImageData(data=data, mime_type=str(mime or "image/png")))
         return images_data

--- a/core/reference_collector.py
+++ b/core/reference_collector.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from astrbot.api import logger
 
 from .logging_utils import log_prefix, mask_sensitive, safe_log_text, safe_log_url
-from .types import ImageCapability
+from .types import ImageCapability, ImageData
 
 if TYPE_CHECKING:
     from astrbot.api.event import AstrMessageEvent
@@ -18,6 +18,14 @@ if TYPE_CHECKING:
 
 
 LOG = log_prefix("Reference")
+
+
+def ensure_image_data(item: ImageData | tuple[bytes, str]) -> ImageData:
+    """Normalize legacy (data, mime) tuples into ImageData."""
+    if isinstance(item, ImageData):
+        return item
+    data, mime = item
+    return ImageData(data=data, mime_type=mime)
 
 
 def normalize_string_items(raw: Any) -> list[str]:
@@ -58,25 +66,26 @@ def resolve_avatar_user_id(event: Any, ref: str) -> str | None:
 
 
 def deduplicate_reference_images(
-    images_data: list[tuple[bytes, str]],
+    images_data: list[ImageData],
     *,
     task_id: str | None = None,
     log_context: str = "Reference",
-) -> list[tuple[bytes, str]]:
+) -> list[ImageData]:
     """Remove duplicate reference images by content hash."""
     if len(images_data) < 2:
         return images_data
 
-    unique_images: list[tuple[bytes, str]] = []
+    unique_images: list[ImageData] = []
     seen_hashes: set[str] = set()
     duplicate_count = 0
-    for data, mime in images_data:
-        digest = hashlib.sha256(data).hexdigest()
+    for image in images_data:
+        image = ensure_image_data(image)
+        digest = hashlib.sha256(image.data).hexdigest()
         if digest in seen_hashes:
             duplicate_count += 1
             continue
         seen_hashes.add(digest)
-        unique_images.append((data, mime))
+        unique_images.append(image)
 
     if duplicate_count:
         task_log = log_prefix(log_context, task_id) if task_id else LOG
@@ -90,9 +99,9 @@ async def collect_reference_images_from_personas(
     *,
     task_id: str | None = None,
     log_context: str = "Reference",
-) -> list[tuple[bytes, str]]:
+) -> list[ImageData]:
     """Download all configured persona reference images."""
-    images_data: list[tuple[bytes, str]] = []
+    images_data: list[ImageData] = []
     task_log = log_prefix(log_context, task_id) if task_id else LOG
     for persona_name, persona_image in persona_images:
         if persona_image_data := await image_processor.download_image(persona_image):
@@ -111,9 +120,9 @@ async def download_reference_images(
     reference_label: str,
     task_id: str | None = None,
     log_context: str = "Reference",
-) -> list[tuple[bytes, str]]:
+) -> list[ImageData]:
     """Download explicit reference images from URLs or local file paths."""
-    images_data: list[tuple[bytes, str]] = []
+    images_data: list[ImageData] = []
     task_log = log_prefix(log_context, task_id) if task_id else LOG
     for reference in normalize_string_items(references):
         if image_data := await image_processor.download_image(reference):
@@ -131,7 +140,7 @@ async def collect_command_reference_images(
     persona_images: list[tuple[str, str]],
     *,
     task_id: str,
-) -> list[tuple[bytes, str]]:
+) -> list[ImageData]:
     """Collect command persona and message reference images."""
     images_data = await collect_reference_images_from_personas(
         image_processor,
@@ -156,7 +165,7 @@ async def collect_tool_reference_images(
     avatar_references: Any = None,
     persona_images: list[tuple[str, str]] | None = None,
     task_id: str | None = None,
-) -> list[tuple[bytes, str]]:
+) -> list[ImageData]:
     """Collect LLM tool persona, URL/path, and avatar reference images."""
     task_log = log_prefix("LLMTool", task_id) if task_id else LOG
     if not (capabilities & ImageCapability.IMAGE_TO_IMAGE):
@@ -164,7 +173,7 @@ async def collect_tool_reference_images(
             logger.warning(f"{task_log} 当前适配器不支持参考图，已忽略工具参考图参数")
         return []
 
-    images_data: list[tuple[bytes, str]] = []
+    images_data: list[ImageData] = []
     avatar_user_ids: set[str] = set()
 
     if persona_images:
@@ -193,7 +202,7 @@ async def collect_tool_reference_images(
             continue
         avatar_user_ids.add(user_id)
         if avatar_data := await image_processor.get_avatar(user_id):
-            images_data.append((avatar_data, "image/jpeg"))
+            images_data.append(ImageData(data=avatar_data, mime_type="image/jpeg"))
             logger.debug(
                 f"{task_log} 已添加 {mask_sensitive(user_id)} 的头像作为参考图"
             )

--- a/core/types.py
+++ b/core/types.py
@@ -15,6 +15,7 @@ class AdapterType(str, enum.Enum):
     SILICONFLOW = "siliconflow_adapter"
     VOLCENGINE_ARK = "volcengine_ark"
     GITEE_AI = "gitee_ai"
+    AGNES_AI = "agnes_ai"
     JIMENG2API = "jimeng2api"
     GROK = "grok"
 
@@ -59,10 +60,11 @@ class AdapterConfig:
 
 @dataclass
 class ImageData:
-    """带有 MIME 类型的图像二进制数据。"""
+    """带有 MIME 类型和可选来源 URL 的图像数据。"""
 
     data: bytes
     mime_type: str
+    source_url: str | None = None
 
 
 @dataclass

--- a/core/utils.py
+++ b/core/utils.py
@@ -56,7 +56,9 @@ def detect_mime_type(data: bytes) -> str:
     return "application/octet-stream"
 
 
-def _sync_convert_image_format(image_data: bytes, mime_type: str) -> ImageData:
+def _sync_convert_image_format(
+    image_data: bytes, mime_type: str, source_url: str | None = None
+) -> ImageData:
     """同步将不支持的图像转换为 JPEG。"""
 
     try:
@@ -74,26 +76,34 @@ def _sync_convert_image_format(image_data: bytes, mime_type: str) -> ImageData:
         output = BytesIO()
         img.save(output, format="JPEG", quality=95)
         logger.debug(f"{LOG} 已将图像转换为 JPEG")
-        return ImageData(data=output.getvalue(), mime_type="image/jpeg")
+        return ImageData(
+            data=output.getvalue(), mime_type="image/jpeg", source_url=source_url
+        )
     except Exception as exc:  # noqa: BLE001
         logger.error(f"{LOG} 图像转换失败: {exc}")
-        return ImageData(data=image_data, mime_type=mime_type)
+        return ImageData(data=image_data, mime_type=mime_type, source_url=source_url)
 
 
-async def convert_image_format(image_data: bytes, mime_type: str) -> ImageData:
+async def convert_image_format(
+    image_data: bytes, mime_type: str, source_url: str | None = None
+) -> ImageData:
     """如果 MIME 类型不支持，则转换图像。"""
 
     real_mime = detect_mime_type(image_data)
     if real_mime in SUPPORTED_IMAGE_FORMATS:
-        return ImageData(data=image_data, mime_type=real_mime)
+        return ImageData(data=image_data, mime_type=real_mime, source_url=source_url)
     logger.debug(f"{LOG} 正在转换图像格式: {mime_type} -> image/jpeg")
-    return await asyncio.to_thread(_sync_convert_image_format, image_data, mime_type)
+    return await asyncio.to_thread(
+        _sync_convert_image_format, image_data, mime_type, source_url
+    )
 
 
 async def convert_images_batch(images: Iterable[ImageData]) -> list[ImageData]:
     """并行批量转换图像。"""
 
-    tasks = [convert_image_format(img.data, img.mime_type) for img in images]
+    tasks = [
+        convert_image_format(img.data, img.mime_type, img.source_url) for img in images
+    ]
     return await asyncio.gather(*tasks)
 
 

--- a/main.py
+++ b/main.py
@@ -254,7 +254,7 @@ class ImageGenerationPlugin(Star):
         task_id: str,
         source: str,
         prompt: str,
-        images_data: list[tuple[bytes, str]] | None,
+        images_data: list[ImageData] | None,
         unified_msg_origin: str,
         aspect_ratio: str,
         resolution: str,
@@ -640,7 +640,7 @@ class ImageGenerationPlugin(Star):
         self,
         prompt: str,
         unified_msg_origin: str,
-        images_data: list[tuple[bytes, str]] | None = None,
+        images_data: list[ImageData] | None = None,
         aspect_ratio: str = "1:1",
         resolution: str = "1K",
         image_count: int = 1,
@@ -703,8 +703,12 @@ class ImageGenerationPlugin(Star):
 
         images: list[ImageData] = []
         if images_data:
-            for data, mime in images_data:
-                images.append(ImageData(data=data, mime_type=mime))
+            for image in images_data:
+                if isinstance(image, ImageData):
+                    images.append(image)
+                else:
+                    data, mime = image
+                    images.append(ImageData(data=data, mime_type=mime))
         self.task_manager.update_generation_task_references(
             task_id,
             reference_image_count=len(images),
@@ -1231,7 +1235,7 @@ class ImageGenerationPlugin(Star):
             return
 
         task_id = hashlib.md5(f"{time.time()}{user_id}".encode()).hexdigest()[:8]
-        images_data: list[tuple[bytes, str]] | None = None
+        images_data: list[ImageData] | None = None
         if self.generator.adapter.get_capabilities() & ImageCapability.IMAGE_TO_IMAGE:
             try:
                 images_data = await collect_command_reference_images(


### PR DESCRIPTION
## Summary

Adds an `agnes_ai` provider adapter for Agnes AI image models and wires it into the existing generic image generation pipeline.

Closes #28.

Official Agnes AI documentation used for this adapter:

- https://agnes-ai.com/doc/agnes-image-20-flash
- https://agnes-ai.com/doc/agnes-image-21-flash

## What changed

- Added `AgnesAIAdapter` for `POST /v1/images/generations`.
- Registered `AdapterType.AGNES_AI` in the provider factory and adapter exports.
- Added `agnes_ai` provider configuration schema with models:
  - `agnes-image-2.0-flash`
  - `agnes-image-2.1-flash`
- Added request payload handling for:
  - text-to-image
  - image-to-image / multi-image input through `extra_body.image`
  - URL response format through `extra_body.response_format = "url"`
  - `tags: ["img2img"]` for `agnes-image-2.0-flash` image-to-image requests
  - optional 2.0 `seed`
- Mapped the plugin's aspect ratio and resolution settings to Agnes' documented `size` field.
- Documented that Agnes does not receive an `aspect_ratio` field; aspect ratio support is implemented only by mapping to `size`.
- Preserved reference-image metadata through `ImageData.source_url` while keeping legacy `(bytes, mime)` tuple compatibility.
- Kept reference image conversion centralized so adapters receive converted `ImageData` consistently.

## Important API compatibility notes

The official Agnes AI docs document `size`, not `aspect_ratio`.

This PR therefore does **not** send an `aspect_ratio` request field to Agnes AI. When the plugin has a global aspect ratio configured, the Agnes adapter maps it to the official `size` field instead.

Example for global `9:16` + `2K`:

```json
{
  "model": "agnes-image-2.1-flash",
  "prompt": "...",
  "size": "1152x2048",
  "extra_body": {
    "response_format": "url"
  }
}
```

For image-to-image requests, reference images are included under `extra_body.image`. The adapter sends data URLs for collected platform images so remote Agnes servers do not need access to platform-authenticated temporary URLs.

## Root cause addressed

Without declaring Agnes as supporting the plugin's aspect-ratio flow, the common generation pipeline can strip the configured global aspect ratio before the request reaches the adapter. That causes Agnes requests to omit `size`, which can produce default square images even when users configured a portrait aspect ratio such as `9:16`.

This PR keeps the common plugin behavior intact while making Agnes translate that setting into the API's documented `size` field.

## Validation

Ran:

```bash
python -m compileall adapter core main.py
python -m json.tool _conf_schema.json
```

Also verified with an isolated payload check that:

- `9:16` + `2K` maps to `size: "1152x2048"`.
- Agnes payloads do not include `aspect_ratio`.
- Image-to-image payloads include `extra_body.image`.
- Missing/partial capability configuration still allows Agnes to retain the plugin aspect-ratio setting for `size` mapping.

## Risk and compatibility

- Existing providers continue to use their existing adapter classes and request formats.
- Shared reference-image handling now uses `ImageData` with an optional `source_url`, while preserving tuple fallback for older call sites.
- The Agnes capability label for aspect ratio is documented as an internal mapping to `size`, not an Agnes API field.