### PR TITLE
feat: add Agnes response format and debug JSON logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,18 @@
 
 ## 适配器
 
-| 适配器类型            | 使用接口类型                                                   | 文生图 | 图生图 | 尺寸控制 | 说明                                                                                                                                                                                                          |
-| :-------------------- | :------------------------------------------------------------- | :----: | :----: | :------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `gemini`              | Gemini 原生 `generateContent`                                  |   ✅    |   ✅    |    ✅     | Gemini 原生图像生成接口。                                                                                                                                                                                     |
-| `openai_chat`         | OpenAI 兼容 `chat/completions`                                 |   ✅    |   ✅    |    ❌     | 通用 Chat Completions 图像生成接口，可配置 `modalities`、提示词前缀和额外请求体。                                                                                                                             |
-| `openai`              | OpenAI Images API `/v1/images/generations`、`/v1/images/edits` |   ✅    |   ✅    |    ✅     | DALL-E / GPT Image 系列；图生图仅 GPT Image 系列支持。                                                                                                                                                        |
-| `volcengine_ark`      | 火山方舟 Images Generations `/api/v3/images/generations`       |   ✅    |   ✅    |    ✅     | Seedream 系列，支持单图和组图；参考图使用 `image` 字段。                                                                                                                                                      |
-| `gitee_ai`            | Gitee AI `/v1/images/generations`、`/v1/images/edits`          |   ✅    |   ✅    |    ✅     | Gitee AI 通用图像接口                                                                                                                                                                                         |
-| `jimeng2api`          | jimeng-api `/v1/images/generations`、`/v1/images/compositions` |   ✅    |   ✅    |    ✅     | 适用于 [iptag/jimeng-api](https://github.com/iptag/jimeng-api)。                                                                                                                                              |
-| `grok`                | xAI Images API `/v1/images/generations`、`/v1/images/edits`    |   ✅    |   ✅    |    ✅     | Grok / xAI 图像生成接口。                                                                                                                                                                                     |
-| `siliconflow_adapter` | SiliconFlow Images API `/v1/images/generations`                |   ✅    |   ✅    |    ✅     | 支持 Kolors、Qwen-Image、Qwen-Image-Edit、Z-Image；多参考图映射到 `image`、`image2`、`image3`。                                                                                                               |
-| `agnes_ai`            | Agnes AI Images API `/v1/images/generations`                   |   ✅    |   ✅    |    ✅     | 支持 `agnes-image-2.0-flash` 和 `agnes-image-2.1-flash`；宽高比会在插件内映射为官方 `size` 字段，不会发送 `aspect_ratio` 字段；2.0 图生图会自动附加 `tags: ["img2img"]`，参考图通过 `extra_body.image` 发送。 |
-| `custom_http`         | 用户自定义 HTTP JSON 接口                                      |   ✅    |   ✅    |    ✅     | 高级接口模板，详见 [自定义 HTTP 接口配置](docs/custom-http.md)。                                                                                                                                              |
-
+| 适配器类型            | 使用接口类型                                                   | 文生图 | 图生图 | 尺寸控制 | 说明                                                                                            |
+| :-------------------- | :------------------------------------------------------------- | :----: | :----: | :------: | :---------------------------------------------------------------------------------------------- |
+| `gemini`              | Gemini 原生 `generateContent`                                  |   ✅    |   ✅    |    ✅     | Gemini 原生图像生成接口。                                                                       |
+| `openai_chat`         | OpenAI 兼容 `chat/completions`                                 |   ✅    |   ✅    |    ❌     | 通用 Chat Completions 图像生成接口，可配置 `modalities`、提示词前缀和额外请求体。                |
+| `openai`              | OpenAI Images API `/v1/images/generations`、`/v1/images/edits` |   ✅    |   ✅    |    ✅     | DALL-E / GPT Image 系列；图生图仅 GPT Image 系列支持。                                          |
+| `volcengine_ark`      | 火山方舟 Images Generations `/api/v3/images/generations`       |   ✅    |   ✅    |    ✅     | Seedream 系列，支持单图和组图；参考图使用 `image` 字段。                                        |
+| `gitee_ai`            | Gitee AI `/v1/images/generations`、`/v1/images/edits`          |   ✅    |   ✅    |    ✅     | Gitee AI 通用图像接口                                                                           |
+| `jimeng2api`          | jimeng-api `/v1/images/generations`、`/v1/images/compositions` |   ✅    |   ✅    |    ✅     | 适用于 [iptag/jimeng-api](https://github.com/iptag/jimeng-api)。                                |
+| `grok`                | xAI Images API `/v1/images/generations`、`/v1/images/edits`    |   ✅    |   ✅    |    ✅     | Grok / xAI 图像生成接口。                                                                       |
+| `siliconflow_adapter` | SiliconFlow Images API `/v1/images/generations`                |   ✅    |   ✅    |    ✅     | 支持 Kolors、Qwen-Image、Qwen-Image-Edit、Z-Image；多参考图映射到 `image`、`image2`、`image3`。 |
+| `agnes_ai`            | Agnes AI Images API `/v1/images/generations`                   |   ✅    |   ✅    |    ✅     | 支持 `agnes-image-2.0-flash` 和 `agnes-image-2.1-flash`；参考图通过 `extra_body.image` 数组发送。 |
+| `custom_http`         | 用户自定义 HTTP JSON 接口                                      |   ✅    |   ✅    |    ✅     | 高级接口模板，详见 [自定义 HTTP 接口配置](docs/custom-http.md)。                                |
 
 ## 配置
 
@@ -72,6 +71,7 @@
 | 生图超时时间覆盖 | 单个供应商的超时时间；填 0 使用公共生图配置。                 |
 | 最大重试次数覆盖 | 单个供应商的重试次数；填 0 使用公共生图配置。                 |
 
+Agnes AI 额外提供“响应格式”下拉选项，默认 `base64`。文生图时会发送 `return_base64: true`，图生图时会发送 `extra_body.response_format: "b64_json"`；选择 `url` 时会发送 `extra_body.response_format: "url"` 并下载返回链接。图生图参考图通过 `extra_body.image` 数组发送。宽高比会映射为官方 `size` 字段，不会发送 `aspect_ratio` 字段。
 
 ### 生图配置
 
@@ -80,6 +80,7 @@
 | 生图模型             | 自动选择首个可用模型 | 当前使用的模型，可通过 `/生图模型` 更新。                                                       |
 | 生图超时时间         | 180 秒               | 请求超时时间。                                                                                  |
 | 最大重试次数         | 3                    | 生成失败后的最大重试次数。                                                                      |
+| 打印debug请求日志    | 关闭                 | 开启后以 debug 日志打印 JSON 请求/响应结构；长字符串、图片 Base64 和 data URL 会摘要，不包含 Authorization 请求头。 |
 | 最大并发生图请求数   | 3                    | 同时调用图像模型接口的请求数量上限；多图任务会在该限制内并发请求，完成一个后继续补发剩余请求。  |
 | 默认出图数量         | 1                    | 未在指令末尾或 LLM 工具中指定数量时，单个生图任务默认生成的图片数量。                           |
 | 单次最大出图数量     | 10                   | 单个生图任务最多生成的图片数量；用户请求超过该值时会自动截断。                                  |

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -650,7 +650,7 @@
       },
       "agnes_ai": {
         "name": "Agnes AI 接口",
-        "hint": "调用 Agnes AI 图像生成接口，支持文生图和通过 extra_body.image 的图生图；宽高比会在插件内映射为官方 size 字段，不会发送 aspect_ratio 字段。",
+        "hint": "Agnes AI 图像生成接口。",
         "display_item": "name",
         "hide_hint_in_list": true,
         "items": {
@@ -687,9 +687,19 @@
               "agnes-image-2.1-flash"
             ]
           },
+          "response_format": {
+            "description": "响应格式",
+            "hint": "base64 直接返回图片；url 返回远端链接。",
+            "type": "string",
+            "default": "base64",
+            "options": [
+              "base64",
+              "url"
+            ]
+          },
           "capability_options": {
             "description": "模型能力",
-            "hint": "按当前模型实际能力勾选；Agnes 的“宽高比”仅表示插件会映射为官方 size 字段，不会发送 aspect_ratio 字段。",
+            "hint": "按模型能力勾选；比例映射为 size，不发 aspect_ratio。",
             "type": "list",
             "options": [
               "文生图",
@@ -722,17 +732,6 @@
             "slider": {
               "min": 0,
               "max": 10,
-              "step": 1
-            },
-            "default": 0
-          },
-          "seed": {
-            "description": "随机种子",
-            "hint": "可选；Agnes Image 2.0 Flash 支持。填 0 表示不发送 seed。",
-            "type": "int",
-            "slider": {
-              "min": 0,
-              "max": 2147483647,
               "step": 1
             },
             "default": 0
@@ -1086,6 +1085,12 @@
           "step": 1
         },
         "default": 3
+      },
+      "debug_request_logging": {
+        "description": "打印debug请求日志",
+        "hint": "开启后 debug 打印 JSON 请求/响应结构，长字符串会摘要。",
+        "type": "bool",
+        "default": false
       },
       "non_retryable_status_codes": {
         "description": "不可重试 HTTP 状态码",

--- a/adapter/agnes_ai_adapter.py
+++ b/adapter/agnes_ai_adapter.py
@@ -64,6 +64,7 @@ class AgnesAIAdapter(BaseImageAdapter):
             f"{prefix} 请求 URL: {safe_log_url(url)}, Payload 字段: {list(payload.keys())}, "
             f"参考图={image_count}张"
         )
+        self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with self._get_session().post(
@@ -76,12 +77,13 @@ class AgnesAIAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
 
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data, request.task_id)
         except Exception as e:  # noqa: BLE001
@@ -107,15 +109,20 @@ class AgnesAIAdapter(BaseImageAdapter):
         }
         if size := self._resolve_size(request):
             payload["size"] = size
-        if seed := self._resolve_seed():
-            payload["seed"] = seed
 
-        extra_body: dict[str, Any] = {"response_format": "url"}
+        response_format = self._response_format()
+        extra_body: dict[str, Any] = {}
+        if response_format == "url":
+            extra_body["response_format"] = "url"
+        elif request.images:
+            extra_body["response_format"] = "b64_json"
+        else:
+            payload["return_base64"] = True
+
         if request.images:
-            if self._needs_img2img_tag():
-                payload["tags"] = ["img2img"]
             extra_body["image"] = self._build_image_refs(request.images)
-        payload["extra_body"] = extra_body
+        if extra_body:
+            payload["extra_body"] = extra_body
 
         return payload
 
@@ -123,23 +130,13 @@ class AgnesAIAdapter(BaseImageAdapter):
         """获取当前模型名称。"""
         return self.model or self.DEFAULT_MODEL
 
-    def _needs_img2img_tag(self) -> bool:
-        """Agnes Image 2.0 Flash 的图生图请求需要显式 img2img 标签。"""
-        model_name = self._model_name().lower()
-        return "agnes-image-2.0-flash" in model_name
-
-    def _resolve_seed(self) -> int | None:
-        """解析可选随机种子；填 0 或留空表示不发送。"""
-        if not self._needs_img2img_tag():
-            return None
-        value = self.config.extra.get("seed")
-        if value in (None, "") or isinstance(value, bool):
-            return None
-        try:
-            seed = int(value)
-        except (TypeError, ValueError):
-            return None
-        return seed if seed > 0 else None
+    def _response_format(self) -> str:
+        """解析 Agnes 响应格式配置。"""
+        value = str(self.config.extra.get("response_format") or "base64")
+        normalized = value.strip().lower()
+        if normalized == "url":
+            return "url"
+        return "base64"
 
     def _resolve_size(self, request: GenerationRequest) -> str | None:
         """按宽高比和分辨率解析 Agnes AI size 参数。"""

--- a/adapter/gemini_adapter.py
+++ b/adapter/gemini_adapter.py
@@ -111,6 +111,7 @@ class GeminiAdapter(BaseImageAdapter):
         masked_key = self._get_masked_api_key()
         prefix = self._get_log_prefix(task_id)
         logger.debug(f"{prefix} 请求 -> {safe_log_url(url)}, key={masked_key}")
+        self._log_debug_json("请求", payload, task_id)
 
         headers = {
             "Content-Type": "application/json",
@@ -131,11 +132,12 @@ class GeminiAdapter(BaseImageAdapter):
                 )
                 if response.status != 200:
                     error_text = await response.text()
+                    self._log_debug_json_text("响应", error_text, task_id)
                     logger.error(
                         f"{prefix} 错误 {response.status} (耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return {"error": {"message": f"API 错误 ({response.status})"}}
-                return await response.json()
+                return await self._read_response_json(response, task_id)
         except Exception as e:
             duration = time.time() - start_time
             logger.error(f"{prefix} 请求异常 (耗时: {duration:.2f}s): {e}")

--- a/adapter/gitee_ai_adapter.py
+++ b/adapter/gitee_ai_adapter.py
@@ -108,6 +108,7 @@ class GiteeAIAdapter(BaseImageAdapter):
             logger.debug(
                 f"{prefix} 请求 URL: {safe_log_url(url)}, Payload 字段: {list(payload.keys())}"
             )
+            self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
@@ -120,12 +121,13 @@ class GiteeAIAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
 
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data, request.task_id)
         except Exception as e:  # noqa: BLE001

--- a/adapter/grok_adapter.py
+++ b/adapter/grok_adapter.py
@@ -46,6 +46,7 @@ class GrokAdapter(BaseImageAdapter):
             "Authorization": f"Bearer {self._get_current_api_key()}",
             "Content-Type": "application/json",
         }
+        self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
@@ -58,12 +59,13 @@ class GrokAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
 
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data)
         except Exception as e:

--- a/adapter/jimeng2api_adapter.py
+++ b/adapter/jimeng2api_adapter.py
@@ -62,6 +62,7 @@ class Jimeng2APIAdapter(BaseImageAdapter):
                     payload["ratio"] = request.aspect_ratio
                 if request.resolution and request.resolution != UNSPECIFIED_OPTION:
                     payload["resolution"] = request.resolution.lower()
+                self._log_debug_json("请求", payload, request.task_id)
 
                 async with session.post(
                     url,
@@ -73,12 +74,13 @@ class Jimeng2APIAdapter(BaseImageAdapter):
                     duration = time.time() - start_time
                     if resp.status != 200:
                         error_text = await resp.text()
+                        self._log_debug_json_text("响应", error_text, request.task_id)
                         logger.error(
                             f"{prefix} Compositions 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                         )
                         return None, f"API 错误 ({resp.status})"
 
-                    data_json = await resp.json()
+                    data_json = await self._read_response_json(resp, request.task_id)
                     logger.debug(
                         f"{prefix} Compositions 响应: {safe_log_mapping(data_json)}"
                     )
@@ -98,6 +100,7 @@ class Jimeng2APIAdapter(BaseImageAdapter):
                     payload["ratio"] = request.aspect_ratio
                 if request.resolution and request.resolution != UNSPECIFIED_OPTION:
                     payload["resolution"] = request.resolution.lower()
+                self._log_debug_json("请求", payload, request.task_id)
 
                 async with session.post(
                     url,
@@ -109,12 +112,13 @@ class Jimeng2APIAdapter(BaseImageAdapter):
                     duration = time.time() - start_time
                     if resp.status != 200:
                         error_text = await resp.text()
+                        self._log_debug_json_text("响应", error_text, request.task_id)
                         logger.error(
                             f"{prefix} Generations 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                         )
                         return None, f"API 错误 ({resp.status})"
 
-                    data_json = await resp.json()
+                    data_json = await self._read_response_json(resp, request.task_id)
                     logger.debug(
                         f"{prefix} Generations 响应: {safe_log_mapping(data_json)}"
                     )

--- a/adapter/openai_adapter.py
+++ b/adapter/openai_adapter.py
@@ -68,7 +68,9 @@ class OpenAIAdapter(BaseImageAdapter):
         else:
             url = f"{base}/v1/images/generations"
             headers["Content-Type"] = "application/json"
-            kwargs = {"json": self._build_payload(request)}
+            payload = self._build_payload(request)
+            kwargs = {"json": payload}
+            self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
@@ -81,11 +83,12 @@ class OpenAIAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data)
         except Exception as e:

--- a/adapter/openai_chat_adapter.py
+++ b/adapter/openai_chat_adapter.py
@@ -151,6 +151,7 @@ class OpenAIChatAdapter(BaseImageAdapter):
         masked_key = self._get_masked_api_key()
         prefix = self._get_log_prefix(task_id)
         logger.debug(f"{prefix} 请求 -> {safe_log_url(url)}, key={masked_key}")
+        self._log_debug_json("请求", payload, task_id)
 
         headers = {
             "Authorization": f"Bearer {api_key}",
@@ -171,11 +172,12 @@ class OpenAIChatAdapter(BaseImageAdapter):
                 )
                 if response.status != 200:
                     error_text = await response.text()
+                    self._log_debug_json_text("响应", error_text, task_id)
                     logger.error(
                         f"{prefix} 错误 {response.status} (耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return {"error": {"message": f"API 错误 ({response.status})"}}
-                return await response.json()
+                return await self._read_response_json(response, task_id)
         except Exception as e:
             duration = time.time() - start_time
             logger.error(f"{prefix} 请求异常 (耗时: {duration:.2f}s): {e}")

--- a/adapter/siliconflow_adapter.py
+++ b/adapter/siliconflow_adapter.py
@@ -70,6 +70,7 @@ class SiliconFlowAdapter(BaseImageAdapter):
         logger.debug(
             f"{prefix} 请求 URL: {safe_log_url(url)}, Payload 字段: {list(payload.keys())}"
         )
+        self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
@@ -82,12 +83,13 @@ class SiliconFlowAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
 
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data, request.task_id)
         except Exception as exc:  # noqa: BLE001

--- a/adapter/volcengine_ark_adapter.py
+++ b/adapter/volcengine_ark_adapter.py
@@ -94,6 +94,7 @@ class VolcengineArkAdapter(BaseImageAdapter):
         logger.debug(
             f"{prefix} 请求 URL: {safe_log_url(url)}, Payload 字段: {list(payload.keys())}"
         )
+        self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
@@ -106,12 +107,13 @@ class VolcengineArkAdapter(BaseImageAdapter):
                 duration = time.time() - start_time
                 if resp.status != 200:
                     error_text = await resp.text()
+                    self._log_debug_json_text("响应", error_text, request.task_id)
                     logger.error(
                         f"{prefix} API 错误 ({resp.status}, 耗时: {duration:.2f}s): {safe_log_error_body(error_text)}"
                     )
                     return None, f"API 错误 ({resp.status})"
 
-                data = await resp.json()
+                data = await self._read_response_json(resp, request.task_id)
                 logger.debug(f"{prefix} 生成成功 (耗时: {duration:.2f}s)")
                 return await self._extract_images(data, request.task_id)
         except Exception as exc:  # noqa: BLE001

--- a/core/base_adapter.py
+++ b/core/base_adapter.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import hashlib
+import json
 import re
+from typing import Any
 
 import aiohttp
 
@@ -14,6 +17,10 @@ from .types import AdapterConfig, GenerationRequest, GenerationResult, ImageCapa
 
 
 API_STATUS_ERROR_PATTERN = re.compile(r"API 错误\s*\((\d{3})\)")
+DEBUG_JSON_STRING_LIMIT = 1000
+DEBUG_JSON_EDGE_CHARS = 120
+DEBUG_JSON_LIST_LIMIT = 50
+BASE64_VALUE_RE = re.compile(r"^[A-Za-z0-9+/=\s]+$")
 
 
 class BaseImageAdapter(abc.ABC):
@@ -31,6 +38,7 @@ class BaseImageAdapter(abc.ABC):
         self.timeout = config.timeout
         self.download_timeout = DEFAULT_DOWNLOAD_TIMEOUT
         self.max_retry_attempts = max(1, config.max_retry_attempts)
+        self.debug_request_logging = config.debug_request_logging
         self.non_retryable_status_codes = set(config.non_retryable_status_codes)
         self.non_retryable_error_keywords = [
             keyword.lower()
@@ -94,6 +102,77 @@ class BaseImageAdapter(abc.ABC):
     def _get_download_timeout(self) -> aiohttp.ClientTimeout:
         """获取统一的下载超时配置。"""
         return aiohttp.ClientTimeout(total=self.download_timeout)
+
+    def _log_debug_json(
+        self, label: str, value: Any, task_id: str | None = None
+    ) -> None:
+        """按需输出 JSON 调试日志，长字符串会摘要避免刷屏。"""
+        if not self.debug_request_logging:
+            return
+
+        prefix = self._get_log_prefix(task_id)
+        safe_value = self._sanitize_debug_json(value)
+        json_text = json.dumps(
+            safe_value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            default=str,
+        )
+        logger.debug(f"{prefix} {label} JSON: {json_text}")
+
+    def _sanitize_debug_json(self, value: Any) -> Any:
+        """保留 JSON 结构，同时截断图片 Base64 和其他超长字符串。"""
+        if isinstance(value, dict):
+            return {key: self._sanitize_debug_json(item) for key, item in value.items()}
+        if isinstance(value, list):
+            items = [
+                self._sanitize_debug_json(item)
+                for item in value[:DEBUG_JSON_LIST_LIMIT]
+            ]
+            if len(value) > DEBUG_JSON_LIST_LIMIT:
+                omitted_count = len(value) - DEBUG_JSON_LIST_LIMIT
+                items.append(f"<list truncated: {omitted_count} items omitted>")
+            return items
+        if isinstance(value, str):
+            return self._sanitize_debug_string(value)
+        return value
+
+    def _sanitize_debug_string(self, value: str) -> str:
+        """截断调试 JSON 中可能撑爆日志的字符串值。"""
+        if len(value) <= DEBUG_JSON_STRING_LIMIT:
+            return value
+
+        digest = hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest()[:12]
+        if value.startswith("data:"):
+            media_type = value.split(",", 1)[0]
+            return f"<data-url omitted: {media_type}, len={len(value)}, sha256={digest}>"
+        if BASE64_VALUE_RE.fullmatch(value):
+            return f"<base64 omitted: len={len(value)}, sha256={digest}>"
+
+        head = value[:DEBUG_JSON_EDGE_CHARS]
+        tail = value[-DEBUG_JSON_EDGE_CHARS:]
+        return f"{head}<string truncated: len={len(value)}, sha256={digest}>{tail}"
+
+    def _log_debug_json_text(
+        self, label: str, value: str, task_id: str | None = None
+    ) -> None:
+        """当文本响应可解析为 JSON 时按需输出 JSON 调试日志。"""
+        if not self.debug_request_logging:
+            return
+
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return
+        self._log_debug_json(label, parsed, task_id)
+
+    async def _read_response_json(
+        self, response: aiohttp.ClientResponse, task_id: str | None = None
+    ) -> Any:
+        """读取响应 JSON，并在开关开启时输出安全摘要后的响应体。"""
+        data = await response.json()
+        self._log_debug_json("响应", data, task_id)
+        return data
 
     def _rotate_api_key(self) -> None:
         """轮换 API Key。"""

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -86,6 +86,7 @@ ADAPTER_EXTRA_DEFAULTS: dict[AdapterType, dict[str, Any]] = {
         "modalities": ["image", "text"],
     },
     AdapterType.OPENAI: {"model_family": "auto"},
+    AdapterType.AGNES_AI: {"response_format": "base64"},
 }
 LOG = log_prefix("Config")
 
@@ -114,6 +115,7 @@ class GenerationSettings:
     max_image_count: int = DEFAULT_MAX_GENERATION_IMAGE_COUNT
     max_images_per_message: int = DEFAULT_MAX_IMAGES_PER_MESSAGE
     max_concurrent_tasks: int = DEFAULT_MAX_CONCURRENT_TASKS
+    debug_request_logging: bool = False
     non_retryable_status_codes: list[int] = field(
         default_factory=lambda: list(DEFAULT_NON_RETRYABLE_STATUS_CODES)
     )
@@ -290,6 +292,11 @@ class ConfigManager:
                 "max_concurrent_tasks",
                 DEFAULT_MAX_CONCURRENT_TASKS,
                 min_value=1,
+            ),
+            debug_request_logging=self._get_bool(
+                cfg,
+                "debug_request_logging",
+                False,
             ),
             non_retryable_status_codes=self._parse_int_list(
                 cfg.get(
@@ -497,6 +504,9 @@ class ConfigManager:
                 "max_retry_attempts",
                 DEFAULT_MAX_RETRY_ATTEMPTS,
                 min_value=0,
+            ),
+            debug_request_logging=self._get_bool(
+                gen_cfg, "debug_request_logging", False
             ),
             non_retryable_status_codes=self._parse_int_list(
                 gen_cfg.get(

--- a/core/types.py
+++ b/core/types.py
@@ -52,6 +52,7 @@ class AdapterConfig:
     proxy: str | None = None
     timeout: int = 180
     max_retry_attempts: int = 3
+    debug_request_logging: bool = False
     non_retryable_status_codes: list[int] = field(default_factory=list)
     non_retryable_error_keywords: list[str] = field(default_factory=list)
     safety_settings: str | None = None


### PR DESCRIPTION
## Summary

This PR updates the Agnes AI adapter and shared request logging support.

## Changes

- Adds an Agnes `response_format` provider option with `base64` as the default and `url` as an explicit alternative.
- Uses Agnes-specific response controls per mode:
  - text-to-image base64: `return_base64: true`
  - image-to-image base64: `extra_body.response_format: "b64_json"`
  - URL mode: `extra_body.response_format: "url"`
- Keeps Agnes image-to-image reference images under `extra_body.image`.
- Removes obsolete Agnes `seed` config and `tags: ["img2img"]` request handling.
- Adds an opt-in global debug JSON logging switch for provider request/response payloads.
- Logs debug JSON as compact single-line JSON and summarizes very long strings, Base64 values, and data URLs to avoid flooding logs.
- Wires the shared debug JSON helper through JSON-based adapters.
- Shortens Agnes configuration hints and updates README notes for the current Agnes behavior.

## Verification

- `python -m json.tool _conf_schema.json`
- `python -m compileall adapter core main.py`
- Local payload assertion for Agnes image-to-image confirms reference images are sent via `extra_body.image` and no top-level `image` is emitted.
- Local debug logging assertion confirms request/response JSON is logged as compact single-line JSON and large image strings are summarized.

Fixes #32