### PR TITLE
feat: add Codex Responses image provider

### DIFF
--- a/.astrbot-plugin/i18n/en-US.json
+++ b/.astrbot-plugin/i18n/en-US.json
@@ -598,6 +598,39 @@
             "hint": "Set to 0 to use the retry count from Runtime Control."
           }
         },
+        "codex_responses": {
+          "name": "Codex Responses API",
+          "hint": "Calls the fixed POST /codex/responses image-generation endpoint. The request always contains model, input, and an image_generation tool with output_format=png, and the API must return the image in the same response.",
+          "base_url": {
+            "description": "API endpoint",
+            "hint": "Enter the official OpenAI Codex endpoint https://chatgpt.com/backend-api/codex/responses, or its service root https://chatgpt.com/backend-api. The plugin normalizes the URL and appends /codex/responses; do not include query parameters."
+          },
+          "proxy": {
+            "description": "Proxy URL",
+            "hint": "Optional. Example: http://127.0.0.1:7890."
+          },
+          "api_keys": {
+            "description": "API keys",
+            "hint": "Sent with Authorization: Bearer <API Key>. Multiple keys are rotated when a request is retried."
+          },
+          "available_models": {
+            "description": "Available models",
+            "hint": "Used by the /生图模型 command. Enter a Codex model supported by the configured endpoint."
+          },
+          "capability_options": {
+            "description": "Model capabilities",
+            "hint": "This protocol supports text-to-image and image editing. When reference images are present, they are sent through a multimodal Responses input; aspect ratios and resolutions are not sent to the Codex Responses request.",
+            "labels": ["Text to image", "Image to image"]
+          },
+          "timeout": {
+            "description": "Timeout override (seconds)",
+            "hint": "Set to 0 to use the timeout from Runtime Control."
+          },
+          "max_retry_attempts": {
+            "description": "Retry count override",
+            "hint": "Set to 0 to use the retry count from Runtime Control. API keys are rotated between retry attempts."
+          }
+        },
         "custom_http": {
           "name": "Custom HTTP API (Beta)",
           "hint": "Advanced configuration: customize JSON request bodies, request headers, and response image extraction paths for HTTP image APIs that return base64, data URLs, or image URLs.",

--- a/.astrbot-plugin/i18n/zh-CN.json
+++ b/.astrbot-plugin/i18n/zh-CN.json
@@ -292,6 +292,11 @@
             ]
           }
         },
+        "codex_responses": {
+          "capability_options": {
+            "labels": ["文生图", "图生图"]
+          }
+        },
         "custom_http": {
           "request_method": {
             "labels": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### 更新日志
+- **Unreleased**
+  - 新增 `codex_responses` 专用图片生成适配器，固定请求 `POST /codex/responses`，发送 `model`、`input` 和带 `output_format=png` 的 `image_generation` 工具；支持 Responses 多模态 `input_image` 图生图。
+  - 支持解析 Responses 风格 `output[*].type == image_generation_call` 的 `result` 图片数据，并兼容 Base64、data URL、图片 URL 与常见中转包装字段。
+  - 新增中英文 WebUI 配置模板和 Codex Responses 使用文档；支持同步文生图和图生图，不支持宽高比、分辨率、SSE 或异步轮询。
+
 - **v1.5.1-2026-07-14**
   - 新增 `dashboard` 插件 Page，可在 AstrBot WebUI 中提交生图任务、查看任务队列和详情、取消任务并下载生成结果。
   - 新增 Page 后端 API，支持状态查询、任务查询、任务提交、参考图上传、任务取消和结果图片下载。

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 | `agnes_ai`            | Agnes AI Images API `/v1/images/generations`                   |   ✅    |   ✅    |    ✅     | 支持 `agnes-image-2.0-flash` 和 `agnes-image-2.1-flash`；参考图通过 `extra_body.image` 数组发送。 |
 | `jimeng2api`          | jimeng-api `/v1/images/generations`、`/v1/images/compositions` |   ✅    |   ✅    |    ✅     | 适用于 [iptag/jimeng-api](https://github.com/iptag/jimeng-api)，支持启动和每日自动领积分任务。   |
 | `grok`                | xAI Images API `/v1/images/generations`、`/v1/images/edits`    |   ✅    |   ✅    |    ✅     | Grok / xAI 图像生成接口。                                                                       |
+| `codex_responses`     | Codex Responses API `/codex/responses`                         |   ✅    |   ✅    |    ❌     | 固定请求 `model`、`input` 和 `image_generation` 工具；支持同步图像编辑。                         |
 | `custom_http`         | 用户自定义 HTTP JSON 接口                                      |   ✅    |   ✅    |    ✅     | 高级接口模板，详见 [自定义 HTTP 接口配置](docs/custom-http.md)。                                |
 
 > 能力开关以“模型能力”配置为准。未勾选的能力不会在请求中使用，LLM 工具参数也会按当前适配器能力动态隐藏。
@@ -83,6 +84,7 @@
 - `gitee_ai`：可通过图像接口模式自动或手动选择 `generations` / `edits`。
 - `siliconflow_adapter`：可配置反向提示词、推理步数和提示词遵循强度。
 - `agnes_ai`：可选择 `base64` 或 `url` 响应格式；图生图参考图通过 `extra_body.image` 数组发送。
+- `codex_responses`：固定向 `POST /codex/responses` 发送 `model`、`input` 与 `tools: [{"type":"image_generation","output_format":"png"}]`；填写服务根地址后会自动拼接路径，使用 Bearer API Key。无参考图时发送文本 `input`，有参考图时发送多模态 Responses `input`，仅支持同步结果；详见 [Codex Responses 接口配置](docs/codex-responses.md)。
 - `custom_http`：可配置请求方法、请求头、查询参数、请求体、图片结果路径、结果类型、错误路径和成功状态码。
 
 ### 生成与结果配置
@@ -267,6 +269,7 @@ LLM 生图工具支持 `preset`、`persona`、`aspect_ratio`、`resolution`、`i
 - 火山方舟的可用模型列表需要按控制台实际 Model ID 或 Endpoint ID 配置。
 - 配置 `jimeng2api` 后，插件会在启动时和每天日期变更后自动领取积分；仅直接连接即梦逆向服务时有效。
 - 即梦逆向图生图使用 `/v1/images/compositions`，使用中转可能会导致图生图失败。
+- Codex Responses 接口支持在单次 HTTP 请求内返回最终图片的文生图和图生图；参考图会作为多模态 `input_image` data URL 发送，但宽高比和分辨率会被忽略。若日志在约 150 秒显示 `Server disconnected`、后续任务仍成功，通常是服务端或中间网络主动断开后触发了插件重试，而不是本插件的请求超时；详见 [Codex Responses 接口配置](docs/codex-responses.md)。
 - 自定义 HTTP 接口为高级功能，建议先阅读 [自定义 HTTP 接口配置](docs/custom-http.md)。
 - 开启调试请求日志或详细错误信息时，插件会做脱敏和摘要处理，但仍建议避免在公共环境暴露日志。
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -898,6 +898,79 @@
           }
         }
       },
+      "codex_responses": {
+        "name": "Codex Responses 接口",
+        "hint": "调用固定的 POST /codex/responses 图像生成接口。请求体固定使用 model、input 和 image_generation 工具（output_format=png），并要求接口在同一次响应中返回图片。",
+        "display_item": "name",
+        "hide_hint_in_list": true,
+        "items": {
+          "name": {
+            "description": "供应商名称",
+            "hint": "用于显示和模型选择；格式为“供应商名称/模型名称”。",
+            "type": "string",
+            "default": "Codex Responses"
+          },
+          "base_url": {
+            "description": "接口地址",
+            "hint": "填写 OpenAI 官方 Codex 入口 https://chatgpt.com/backend-api/codex/responses，或填写根地址 https://chatgpt.com/backend-api；插件会自动规范化并拼接 /codex/responses，不要填写查询参数。",
+            "type": "string",
+            "default": ""
+          },
+          "proxy": {
+            "description": "代理地址",
+            "hint": "可选，示例：http://127.0.0.1:7890。",
+            "type": "string",
+            "default": ""
+          },
+          "api_keys": {
+            "description": "API 密钥",
+            "hint": "使用 Authorization: Bearer <API Key> 发送；可配置多个用于失败重试时轮换。",
+            "type": "list",
+            "default": []
+          },
+          "available_models": {
+            "description": "可用模型列表",
+            "hint": "用于 /生图模型 命令切换；请按接口实际支持的 Codex 模型填写。",
+            "type": "list",
+            "default": []
+          },
+          "capability_options": {
+            "description": "模型能力",
+            "hint": "支持文生图和图生图：有参考图时会使用 Responses 多模态 input 发送图片；宽高比和分辨率不会发送到 Codex Responses 请求。",
+            "type": "list",
+            "options": [
+              "文生图",
+              "图生图"
+            ],
+            "default": [
+              "文生图",
+              "图生图"
+            ]
+          },
+          "timeout": {
+            "description": "超时时间覆盖（秒）",
+            "hint": "填 0 表示使用“运行控制”中的超时时间。",
+            "type": "int",
+            "slider": {
+              "min": 0,
+              "max": 600,
+              "step": 10
+            },
+            "default": 0
+          },
+          "max_retry_attempts": {
+            "description": "重试次数覆盖",
+            "hint": "填 0 表示使用“运行控制”中的重试次数；重试时会自动轮换 API Key。",
+            "type": "int",
+            "slider": {
+              "min": 0,
+              "max": 10,
+              "step": 1
+            },
+            "default": 0
+          }
+        }
+      },
       "custom_http": {
         "name": "自定义 HTTP 接口(Beta)",
         "hint": "高级配置：自定义 JSON 请求体、请求头和响应图片提取路径，适配任意返回 base64、data URL 或图片 URL 的 HTTP 生图接口。",

--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -1,6 +1,7 @@
 """Adapter module for the image generation plugin."""
 
 from .agnes_ai_adapter import AgnesAIAdapter
+from .codex_responses_adapter import CodexResponsesAdapter
 from .custom_http_adapter import CustomHTTPAdapter
 from .gemini_adapter import GeminiAdapter
 from .gitee_ai_adapter import GiteeAIAdapter
@@ -13,6 +14,7 @@ from .volcengine_ark_adapter import VolcengineArkAdapter
 
 __all__ = [
     "AgnesAIAdapter",
+    "CodexResponsesAdapter",
     "CustomHTTPAdapter",
     "GeminiAdapter",
     "OpenAIChatAdapter",

--- a/adapter/codex_responses_adapter.py
+++ b/adapter/codex_responses_adapter.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import time
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from astrbot.api import logger
+
+from ..core.adapters.base import BaseImageAdapter
+from ..core.shared.logging import safe_log_error_body, safe_log_url, safe_log_text
+from ..core.shared.types import GenerationRequest, GenerationResult, ImageCapability
+
+
+class CodexResponsesAdapter(BaseImageAdapter):
+    """Adapter for synchronous Codex Responses image generation endpoints."""
+
+    def get_capabilities(self) -> ImageCapability:
+        """Return the capabilities defined by the Codex Responses request format."""
+        return ImageCapability.TEXT_TO_IMAGE | ImageCapability.IMAGE_TO_IMAGE
+
+    def _pre_generate(self, _request: GenerationRequest) -> GenerationResult | None:
+        """Validate the fixed endpoint configuration before making a request."""
+        if not self.model.strip():
+            return GenerationResult(images=None, error="未配置 Codex Responses 模型")
+        _, error = self._build_responses_url()
+        if error:
+            return GenerationResult(images=None, error=error)
+        return None
+
+    async def _generate_once(
+        self, request: GenerationRequest
+    ) -> tuple[list[bytes] | None, str | None]:
+        """Send one synchronous image-generation request to Codex Responses."""
+        url, url_error = self._build_responses_url()
+        if url_error:
+            return None, url_error
+
+        payload = self._build_payload(request)
+        api_key = self._get_current_api_key()
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, image/*",
+        }
+        start_time = time.time()
+        self._log_request_overview(
+            request,
+            url,
+            payload=payload,
+            extra={
+                "API Key": "已配置" if api_key else "未配置",
+                "超时配置": f"{self.timeout}秒",
+            },
+        )
+        self._log_debug_json("请求", payload, request.task_id)
+
+        try:
+            async with self._get_session().post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=self._get_timeout(),
+                proxy=self.proxy,
+            ) as response:
+                duration = time.time() - start_time
+                body = await response.read()
+                self._log_response_status(request, response.status, duration)
+                if not 200 <= response.status < 300:
+                    error_text = body.decode("utf-8", errors="replace")
+                    self._log_debug_json_text("响应", error_text, request.task_id)
+                    self._log_api_error(
+                        request,
+                        response.status,
+                        duration,
+                        error_text,
+                        label="Codex Responses 错误",
+                    )
+                    return None, self._format_http_error(response.status, error_text)
+
+                content_type = response.headers.get("Content-Type", "").lower()
+                if content_type.startswith("image/"):
+                    return [body], None
+
+                response_data, parse_error = self._parse_response_json(body, request.task_id)
+                if parse_error:
+                    return None, parse_error
+                if not isinstance(response_data, dict):
+                    return None, "Codex Responses 响应必须是 JSON 对象"
+
+                if error := self._response_error_message(response_data):
+                    return None, error
+
+                images = await self._extract_images(response_data, request.task_id)
+                if images:
+                    return images, None
+
+                self._log_missing_image_response(response_data, request.task_id)
+                return None, self._no_image_error(response_data)
+        except Exception as exc:  # noqa: BLE001
+            duration = time.time() - start_time
+            self._log_request_exception(
+                request,
+                duration,
+                exc,
+                label=f"Codex Responses 请求异常 (配置超时 {self.timeout}s)",
+            )
+            return None, safe_log_error_body(exc)
+
+    def _build_payload(self, request: GenerationRequest) -> dict[str, Any]:
+        """Build a text-only or multimodal Responses request payload."""
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "tools": [self._build_image_generation_tool()],
+        }
+        if not request.images:
+            payload["input"] = request.prompt
+            return payload
+
+        content: list[dict[str, str]] = [
+            {"type": "input_text", "text": request.prompt}
+        ]
+        for image in request.images:
+            encoded = base64.b64encode(image.data).decode("ascii")
+            content.append(
+                {
+                    "type": "input_image",
+                    "image_url": f"data:{image.mime_type};base64,{encoded}",
+                }
+            )
+        payload["input"] = [{"role": "user", "content": content}]
+        return payload
+
+    def _build_image_generation_tool(self) -> dict[str, str]:
+        """Build the verified image-generation tool declaration."""
+        return {
+            "type": "image_generation",
+            "output_format": "png",
+        }
+
+    def _build_responses_url(self) -> tuple[str, str | None]:
+        """Normalize a configured service root to its fixed Codex Responses path."""
+        base = (self.base_url or "").strip()
+        if not base:
+            return "", "未配置 Codex Responses 接口地址"
+
+        parsed = urlsplit(base)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return "", "Codex Responses 接口地址必须是有效的 http(s) URL"
+        if parsed.query or parsed.fragment:
+            return "", "Codex Responses 接口地址不能包含查询参数或片段"
+
+        path = parsed.path.rstrip("/")
+        if path.endswith("/codex/responses"):
+            endpoint_path = path
+        elif path.endswith("/codex"):
+            endpoint_path = f"{path}/responses"
+        else:
+            if path.endswith("/v1"):
+                path = path[: -len("/v1")]
+            endpoint_path = f"{path}/codex/responses"
+
+        return urlunsplit((parsed.scheme, parsed.netloc, endpoint_path, "", "")), None
+
+    def _parse_response_json(
+        self, body: bytes, task_id: str | None
+    ) -> tuple[Any, str | None]:
+        """Decode a JSON response while keeping debug logs safely summarized."""
+        try:
+            text = body.decode("utf-8")
+        except UnicodeDecodeError:
+            return None, "Codex Responses 响应不是 JSON 且不是图片数据"
+
+        try:
+            response_data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                f"{self._get_log_prefix(task_id)} Codex Responses JSON 解析失败: "
+                f"{safe_log_error_body(exc)}"
+            )
+            return None, "Codex Responses 响应 JSON 解析失败"
+
+        self._log_debug_json("响应", response_data, task_id)
+        return response_data, None
+
+    def _format_http_error(self, status: int, error_text: str) -> str:
+        """Preserve retryable upstream failures wrapped in a 4xx response."""
+        normalized = error_text.lower()
+        upstream_statuses = re.findall(r"http\s+(502|503|504)\b", normalized)
+        if (
+            "upstream_error" in normalized
+            or "upstream request failed" in normalized
+            or upstream_statuses
+        ):
+            upstream_status = upstream_statuses[-1] if upstream_statuses else "502"
+            return f"API 错误 ({upstream_status}): 上游服务暂时不可用"
+        return self._format_api_error_message(status, error_text)
+
+    def _response_error_message(self, response_data: dict[str, Any]) -> str | None:
+        """Return a concise error for completed error responses before image parsing."""
+        error = response_data.get("error")
+        if error not in (None, "", {}, []):
+            return self._format_response_error("Codex Responses 返回错误", error)
+
+        status = str(response_data.get("status") or "").strip().lower()
+        if status in {"failed", "error", "cancelled", "canceled"}:
+            detail = (
+                response_data.get("message")
+                or response_data.get("reason")
+                or response_data.get("code")
+                or status
+            )
+            return self._format_response_error("Codex Responses 请求失败", detail)
+        return None
+
+    def _format_response_error(self, prefix: str, detail: Any) -> str:
+        """Add an optional sanitized remote detail to a response error."""
+        if not self.show_user_error_details:
+            return prefix
+        safe_detail = safe_log_text(detail, 300)
+        return f"{prefix}: {safe_detail}" if safe_detail else prefix
+
+    async def _extract_images(
+        self, response_data: dict[str, Any], task_id: str | None
+    ) -> list[bytes]:
+        """Extract images from standard Responses output and proxy-compatible fallbacks."""
+        images: list[bytes] = []
+        output = response_data.get("output")
+        if isinstance(output, list):
+            for item in output:
+                if not isinstance(item, dict) or item.get("type") != "image_generation_call":
+                    continue
+                images.extend(await self._decode_call_images(item, task_id))
+
+        if images:
+            return images
+
+        for field in ("result", "result_b64", "b64_json", "base64", "url"):
+            if field in response_data:
+                decoded = await self._decode_image_value(response_data[field], task_id)
+                if decoded:
+                    images.extend(decoded)
+
+        data = response_data.get("data")
+        if isinstance(data, list):
+            for item in data:
+                decoded = await self._decode_image_value(item, task_id)
+                if decoded:
+                    images.extend(decoded)
+
+        return images
+
+    async def _decode_call_images(
+        self, call: dict[str, Any], task_id: str | None
+    ) -> list[bytes]:
+        """Decode one image_generation_call, preferring its documented result field."""
+        status = str(call.get("status") or "").strip().lower()
+        if status in {"failed", "error", "cancelled", "canceled"}:
+            logger.warning(
+                f"{self._get_log_prefix(task_id)} image_generation_call 失败: "
+                f"{safe_log_text(call.get('error') or call.get('message') or status, 200)}"
+            )
+            return []
+
+        images: list[bytes] = []
+        for field in ("result", "result_b64", "b64_json", "base64", "url"):
+            if field not in call:
+                continue
+            decoded = await self._decode_image_value(call[field], task_id)
+            if decoded:
+                images.extend(decoded)
+        return images
+
+    async def _decode_image_value(self, value: Any, task_id: str | None) -> list[bytes]:
+        """Decode image candidates represented as bytes, arrays, objects, URLs, or Base64."""
+        if value is None:
+            return []
+        if isinstance(value, bytes):
+            return [value]
+        if isinstance(value, list):
+            images: list[bytes] = []
+            for item in value:
+                images.extend(await self._decode_image_value(item, task_id))
+            return images
+        if isinstance(value, dict):
+            images: list[bytes] = []
+            for field in ("result", "result_b64", "b64_json", "base64", "image", "data", "url"):
+                if field in value:
+                    images.extend(await self._decode_image_value(value[field], task_id))
+            image_url = value.get("image_url")
+            if isinstance(image_url, dict):
+                images.extend(await self._decode_image_value(image_url.get("url"), task_id))
+            elif image_url:
+                images.extend(await self._decode_image_value(image_url, task_id))
+            return images
+        if not isinstance(value, str):
+            return []
+
+        candidate = value.strip()
+        if not candidate:
+            return []
+        if candidate.startswith(("http://", "https://")):
+            downloaded = await self._download_image_from_url(candidate, task_id)
+            return [downloaded] if downloaded else []
+        decoded = self._decode_base64_image(candidate, task_id)
+        return [decoded] if decoded else []
+
+    def _decode_base64_image(self, value: str, task_id: str | None) -> bytes | None:
+        """Decode a raw Base64 value or image data URI without logging its contents."""
+        candidate = value.strip()
+        if candidate.lower().startswith("data:"):
+            header, separator, candidate = candidate.partition(",")
+            if not separator or not header.lower().startswith("data:image/"):
+                return None
+            if ";base64" not in header.lower():
+                return None
+
+        candidate = re.sub(r"\s+", "", candidate)
+        if not candidate:
+            return None
+        try:
+            return base64.b64decode(candidate + "=" * (-len(candidate) % 4), validate=True)
+        except (ValueError, binascii.Error) as exc:
+            logger.warning(
+                f"{self._get_log_prefix(task_id)} 图片 Base64 解码失败: "
+                f"{safe_log_error_body(exc)}"
+            )
+            return None
+
+    async def _download_image_from_url(
+        self, url: str, task_id: str | None) -> bytes | None:
+        """Download an absolute image URL without forwarding the provider API key."""
+        prefix = self._get_log_prefix(task_id)
+        try:
+            async with self._get_session().get(
+                url,
+                proxy=self.proxy,
+                timeout=self._get_download_timeout(),
+            ) as response:
+                if response.status == 200:
+                    return await response.read()
+                logger.warning(
+                    f"{prefix} Codex Responses 图片下载失败: {response.status} - "
+                    f"{safe_log_url(url)}"
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"{prefix} Codex Responses 图片下载异常: {safe_log_error_body(exc)}"
+            )
+        return None
+
+    def _log_missing_image_response(
+        self, response_data: dict[str, Any], task_id: str | None
+    ) -> None:
+        """Log a safe response-shape summary when no image can be extracted."""
+        output_summary: list[dict[str, Any]] = []
+        output = response_data.get("output")
+        if isinstance(output, list):
+            for item in output:
+                if not isinstance(item, dict):
+                    output_summary.append({"value_type": type(item).__name__})
+                    continue
+                result = item.get("result")
+                output_summary.append(
+                    {
+                        "type": item.get("type"),
+                        "status": item.get("status"),
+                        "keys": sorted(item.keys()),
+                        "result_type": type(result).__name__,
+                        "result_length": len(result) if isinstance(result, str) else None,
+                    }
+                )
+        logger.warning(
+            f"{self._get_log_prefix(task_id)} Codex Responses 未返回可用图片: "
+            f"{json.dumps({'status': response_data.get('status'), 'error': response_data.get('error'), 'output': output_summary}, ensure_ascii=False, separators=(',', ':'))}"
+        )
+
+    def _no_image_error(self, response_data: dict[str, Any]) -> str:
+        """Describe an otherwise successful response that contains no usable image."""
+        output = response_data.get("output")
+        if isinstance(output, list) and any(
+            isinstance(item, dict) and item.get("type") == "image_generation_call"
+            for item in output
+        ):
+            return "image_generation_call 中未找到可解码的图片结果"
+        if response_data.get("status") in {"in_progress", "queued"}:
+            return "Codex Responses 返回未完成任务，当前适配器仅支持同步图片响应"
+        return "Codex Responses 响应中未找到图片数据"

--- a/core/adapters/generator.py
+++ b/core/adapters/generator.py
@@ -24,6 +24,7 @@ class ImageGenerator:
         """Create an adapter instance from configuration."""
         from ...adapter import (
             AgnesAIAdapter,
+            CodexResponsesAdapter,
             CustomHTTPAdapter,
             GeminiAdapter,
             GiteeAIAdapter,
@@ -45,6 +46,7 @@ class ImageGenerator:
             AdapterType.AGNES_AI: AgnesAIAdapter,
             AdapterType.JIMENG2API: Jimeng2APIAdapter,
             AdapterType.GROK: GrokAdapter,
+            AdapterType.CODEX_RESPONSES: CodexResponsesAdapter,
             AdapterType.CUSTOM_HTTP: CustomHTTPAdapter,
         }
 

--- a/core/shared/types.py
+++ b/core/shared/types.py
@@ -18,6 +18,7 @@ class AdapterType(str, enum.Enum):
     AGNES_AI = "agnes_ai"
     JIMENG2API = "jimeng2api"
     GROK = "grok"
+    CODEX_RESPONSES = "codex_responses"
     CUSTOM_HTTP = "custom_http"
 
 

--- a/docs/codex-responses.md
+++ b/docs/codex-responses.md
@@ -1,0 +1,222 @@
+# Codex Responses 接口配置
+
+`codex_responses` 适配器用于接入采用 OpenAI Responses 风格的同步图片生成接口。它是专用模板：插件固定构造请求、发送 Bearer API Key，并识别 `image_generation_call` 中的图片结果，不需要手动配置请求体或图片路径。
+
+当前版本支持：
+
+- 固定 `POST /codex/responses` 请求
+- `Authorization: Bearer <API Key>` 认证
+- 同步 JSON 响应
+- 文生图和参考图驱动的图像编辑
+- 标准 `output[*].type == "image_generation_call"` 的 `result` 图片字段
+- 纯 Base64、`data:image/...;base64,...` 和 HTTP(S) 图片 URL
+- 兼容 `result_b64`、`b64_json`、`base64` 以及 `data[*]` 包装的图片结果
+- API Key 轮换、代理、超时、重试与现有任务发送流程
+
+暂不支持：
+
+- 宽高比与分辨率参数
+- 流式 SSE 响应
+- 返回任务 ID 后需要轮询的异步接口
+- 下载图片 URL 时额外转发 API Key 或自定义下载请求头
+
+## 快速配置
+
+1. 在“图像模型供应商”中新增 **Codex Responses 接口**。
+2. 填写供应商名称，例如 `宝宝AI`。
+3. 在“接口地址”填写服务根地址，例如 `https://baobao-ai.com`。
+4. 在“API 密钥”填写宝宝 AI API Key。
+5. 在“可用模型列表”填写服务实际支持的模型，例如 `gpt-5.6-terra`。
+6. 在“生图模型”中选择 `宝宝AI/gpt-5.6-terra`。
+
+接口地址会自动规范化并拼接为 `/codex/responses`。以下填写都会请求同一地址：
+
+| 接口地址 | 实际请求地址 |
+| :--- | :--- |
+| `https://baobao-ai.com` | `https://baobao-ai.com/codex/responses` |
+| `https://baobao-ai.com/` | `https://baobao-ai.com/codex/responses` |
+| `https://baobao-ai.com/v1` | `https://baobao-ai.com/codex/responses` |
+| `https://baobao-ai.com/codex` | `https://baobao-ai.com/codex/responses` |
+| `https://baobao-ai.com/codex/responses` | `https://baobao-ai.com/codex/responses` |
+
+接口地址必须是 `http://` 或 `https://` URL，且不能包含查询参数或片段。
+
+## 固定请求格式
+
+每张图片都会发起一个独立请求；插件现有的多图任务会按请求级并发配置调度这些请求。
+
+请求头：
+
+```http
+Authorization: Bearer <API Key>
+Content-Type: application/json
+```
+
+请求体固定为：
+
+```json
+{
+  "model": "gpt-5.6-terra",
+  "input": "生成一张图片：白色背景中央有一个小的纯蓝色实心圆，不要文字。",
+  "tools": [
+    {
+      "type": "image_generation",
+      "output_format": "png"
+    }
+  ]
+}
+```
+
+其中 `input` 使用插件经过预设、人设和附加提示词合并后的最终文本。文本生图不会额外添加 `messages`、`prompt`、`n`、`stream`、`modalities`、`size`、参考图或尺寸字段。工具声明会固定带 `output_format: "png"`，以匹配已验证的宝宝 AI 请求。
+
+## 图像编辑请求
+
+当用户发送、引用或通过 LLM 工具/公共 API 提供参考图时，插件会复用既有的参考图收集、大小校验、文件类型校验、去重和转换链路，并把每张 `ImageData` 按原顺序编码为 `data:<mime>;base64,...`。此时请求使用 Responses 多模态 `input`：
+
+```json
+{
+  "model": "gpt-5.6-terra",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "将这张图片改成赛博朋克夜景风格，保留人物姿势和画面构图。"
+        },
+        {
+          "type": "input_image",
+          "image_url": "data:image/jpeg;base64,<YOUR_BASE64_IMAGE>"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "type": "image_generation",
+      "output_format": "png"
+    }
+  ]
+}
+```
+
+这与宝宝 AI 的 `gpt-5.6-terra` 编辑请求和同步成功响应已经核验一致。输出仍从：
+
+```text
+response.output[i].type == image_generation_call
+response.output[i].result
+```
+
+读取，`result` 是 Base64 编码的图片二进制。
+
+- 直接发送或引用图片后，可使用 `/生图 <编辑要求>`。
+- LLM 工具的 `reference_images`、`avatar_references` 和带图片的人设会进入同一条图生图链路。
+- 插件公共 API 的 `reference_image_sources` 和 `reference_image_data` 也会进入同一条图生图链路。
+- 多张参考图会全部按顺序作为 `input_image` 发送；宝宝 AI 已验证单张输入。若当前账号或模型限制多图，请只提供一张参考图，插件不会静默截断。
+
+宽高比和分辨率当前仍不会加入 Codex 请求。
+
+## 响应格式
+
+首选解析的标准 Responses 响应形态：
+
+```json
+{
+  "id": "resp_example",
+  "status": "completed",
+  "error": null,
+  "output": [
+    {
+      "type": "reasoning"
+    },
+    {
+      "type": "image_generation_call",
+      "status": "generating",
+      "revised_prompt": "...",
+      "result": "<Base64 编码的 PNG 图像数据>"
+    },
+    {
+      "type": "message",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+插件会扫描所有 `output` 项，筛选 `type` 为 `image_generation_call` 的项目，再优先读取其 `result`。即使该调用项的 `status` 仍是 `generating`，只要同一响应已经给出可解码的 `result`，插件仍会将其作为图片结果处理。
+
+`result` 可以是：
+
+- 纯 Base64 图像数据（宝宝 AI 实测格式）
+- `data:image/png;base64,...` 形式的 data URL
+- 可公开下载的 `http://` 或 `https://` 图片 URL
+
+为兼容常见中转实现，插件也会尝试 `result_b64`、`b64_json`、`base64`、`url`、顶层等价字段以及 `data[*]` 下的图片字段。
+
+如果接口只返回任务 ID、`202 Accepted`、SSE 事件流，或者图片 URL 下载需要另一种认证方式，则此专用适配器不会完成图片生成；这类协议需要独立的异步/流式适配器。
+
+## 能力边界
+
+当前 provider 支持“文生图”和“图生图”。当有参考图时，插件会使用上文的多模态 `input_image` data URL；当没有参考图时，插件保留已验证的字符串 `input` 请求格式。
+
+以下参数仍由统一任务执行器忽略，不会进入 Codex 请求：
+
+- 宽高比
+- 分辨率
+
+请勿在服务端猜测或复用其他 OpenAI 接口的 `size` 或 `quality` 字段；待 Codex Responses 提供明确协议后再扩展。
+
+## 排障
+
+### 出现 `Server disconnected`，但任务最终成功
+
+这不是本插件把请求超时缩短到约 150 秒。Codex provider 的“超时时间覆盖”会传给 `aiohttp.ClientTimeout(total=...)`；例如配置为 `300` 时，客户端总请求超时仍是 300 秒。`Server disconnected` 表示在收到 HTTP 响应前，服务端、显式代理、透明代理、负载均衡、CDN 或其他网络设备主动关闭了底层连接。
+
+插件会将这种无 HTTP 状态码的连接错误视为可重试错误。因此日志可能先显示一次连接异常，随后由重试请求成功，任务最终仍正确保存并发送图片。新版日志会在“适配器请求”与“请求异常”中标出配置的超时秒数，便于确认实际生效值。
+
+排查与解决顺序：
+
+1. 在 Codex provider 中暂时清空“代理地址”后复测；如果问题消失，调整该代理的 HTTP read/idle timeout。
+2. 在宝宝 AI、反向代理、CDN/WAF 或负载均衡侧，将上游/下游的 read、response 或 idle timeout 设为高于插件请求超时（300 秒应留出缓冲）。
+3. 从运行 AstrBot 的同一台机器直接向服务发送同样请求，比较是否仍在约 150 秒断开，以区分插件外的网络链路。
+4. 若服务无法维持同步长连接，应改用服务端提供的异步轮询或流式协议；当前专用适配器只支持同步最终响应。
+
+不要盲目增加客户端 timeout 或无限重试：远端可能已在第一次连接断开前完成生成，重复提交会带来重复生成或重复计费风险。
+
+### `WebSocket API call timeout`
+
+若日志模块名不是 `astrbot_plugin_image_generation`，该错误不由本插件的 Codex HTTP 请求产生。例如 `[astrbot_plugin_videos_analysis.main:...]` 应在视频分析插件或 AstrBot 的 WebSocket 发送链路中单独排查。
+
+### 返回 `API 错误 (401)` 或 `API 错误 (403)`
+
+确认 API Key 是否正确、是否仍有权限，并确保服务端采用标准 Bearer 认证。
+
+### 返回“未配置 Codex Responses 接口地址”
+
+在 provider 中填写服务根地址。不要只填写路径，也不要填写带 query 的临时链接。
+
+### 返回“响应中未找到图片数据”
+
+确认服务端在同一次响应的 `output[*]` 中返回：
+
+```text
+output[*].type == image_generation_call
+output[*].result
+```
+
+若服务端字段不同，可先保留一段脱敏响应并据此扩展专用适配器；也可以改用 `custom_http` 手工配置请求体和图片提取路径。
+
+### 生成图片 URL 下载失败
+
+优先让服务端返回 `result` 的 Base64 或 data URL。当前适配器为避免把 API Key 发送到未知图片域名，不会在下载图片 URL 时携带生成接口的 Authorization 头。
+
+### 接口返回异步任务或持续事件流
+
+当前 provider 仅处理同步完成响应。异步轮询和 SSE 需要独立支持任务状态、取消、超时与重试，不能用本模板直接接入。


### PR DESCRIPTION
新增 `codex_responses` 专用图片生成适配器，用于接入的 Codex Responses 风格图像生成接口

## 主要变更

- 新增固定 `POST /codex/responses` 的专用适配器
- 使用 Bearer API Key 认证
- 支持文生图和 Responses 多模态 `input_image` 图生图
- 固定发送 `image_generation` 工具和 `output_format: "png"`
- 解析 `output[*].type == "image_generation_call"` 的 `result`
- 兼容 Base64、data URL、HTTP(S) URL 及常见中转包装字段
- 解析 `output[*].type == "image_generation_call"` 的 `result`
- 兼容 Base64、data URL、HTTP(S) URL 及常见中转包装字段
- 支持 API Key 轮换、代理、超时和重试
- 保留被外层 4xx 包装的上游 502/503/504 重试语义
- 增加无图片响应的安全结构化诊断日志
- 新增中英文 WebUI 配置模板
- 新增 Codex Responses 配置文档并更新 README 和 CHANGELOG

## 能力边界

- 不发送宽高比或分辨率参数
- 不支持 SSE 流式响应
- 不支持异步任务轮询
- 图片 URL 下载不会转发生成接口的 Authorization 头