### PR TITLE
fix: handle streamed OpenAI image results

### DIFF
--- a/adapter/openai_adapter.py
+++ b/adapter/openai_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import time
 from typing import Any
 
@@ -10,7 +11,7 @@ from astrbot.api import logger
 
 from ..core.adapters.base import BaseImageAdapter
 from ..core.shared.constants import UNSPECIFIED_OPTION
-from ..core.shared.logging import safe_log_error_body
+from ..core.shared.logging import safe_log_error_body, safe_log_url
 from ..core.shared.types import GenerationRequest, ImageCapability
 
 
@@ -70,6 +71,8 @@ class OpenAIAdapter(BaseImageAdapter):
             url = f"{base}/v1/images/generations"
             headers["Content-Type"] = "application/json"
             payload = self._build_payload(request)
+            if is_gpt:
+                payload["stream"] = True
             kwargs = {"json": payload}
             self._log_request_overview(request, url, payload=payload)
             self._log_debug_json("请求", payload, request.task_id)
@@ -98,12 +101,88 @@ class OpenAIAdapter(BaseImageAdapter):
                         resp.status,
                         error_text,
                     )
-                data = await self._read_response_json(resp, request.task_id)
-                return await self._extract_images(data)
+                if (
+                    is_gpt
+                    and "text/event-stream"
+                    in resp.headers.get("Content-Type", "").lower()
+                ):
+                    data = await self._read_stream_response(resp, request.task_id)
+                else:
+                    data = await self._read_response_json(resp, request.task_id)
+                return await self._extract_images(data, request.task_id)
         except Exception as e:
             duration = time.time() - start_time
             self._log_request_exception(request, duration, e)
-            return None, safe_log_error_body(e)
+            error_detail = safe_log_error_body(e)
+            if not error_detail:
+                error_detail = f"{type(e).__name__}: {e!r}"
+            return None, error_detail
+
+    async def _read_stream_response(
+        self, response: aiohttp.ClientResponse, task_id: str | None
+    ) -> dict[str, Any]:
+        """Collect completed image events from an OpenAI-compatible SSE response."""
+        images: list[dict[str, Any]] = []
+        buffer = ""
+        data_lines: list[str] = []
+        stream_error: str | None = None
+
+        def collect_event(payload_text: str) -> None:
+            nonlocal stream_error
+            if not payload_text or payload_text == "[DONE]":
+                return
+            try:
+                event = json.loads(payload_text)
+            except json.JSONDecodeError:
+                return
+            if not isinstance(event, dict):
+                return
+
+            event_type = str(event.get("type", "")).strip().lower()
+            if event_type in {"error", "upstream_error"} or event.get("error"):
+                error = event.get("error")
+                if isinstance(error, dict):
+                    stream_error = str(error.get("message") or error)
+                else:
+                    stream_error = str(event.get("message") or error)
+            elif isinstance(event.get("data"), list):
+                images.extend(item for item in event["data"] if isinstance(item, dict))
+            elif event_type in {
+                "image_generation.completed",
+                "image_edit.completed",
+            }:
+                images.append(event)
+
+        async for chunk in response.content.iter_any():
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.rstrip("\r")
+                if line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+                if line or not data_lines:
+                    continue
+
+                collect_event("\n".join(data_lines).strip())
+                data_lines.clear()
+
+        if buffer.rstrip("\r").startswith("data:"):
+            data_lines.append(buffer.rstrip("\r")[5:].lstrip())
+        if data_lines:
+            collect_event("\n".join(data_lines).strip())
+
+        if stream_error:
+            raise RuntimeError(f"Image stream error: {stream_error}")
+
+        self._log_debug_json(
+            "SSE response",
+            {
+                "event_count": len(images),
+                "image_fields": [list(item) for item in images],
+            },
+            task_id,
+        )
+        return {"data": images}
 
     def _build_payload(self, request: GenerationRequest) -> dict:
         """Build the request payload."""
@@ -163,25 +242,59 @@ class OpenAIAdapter(BaseImageAdapter):
         return mapping.get(aspect_ratio)
 
     async def _extract_images(
-        self, response: dict
+        self, response: dict, task_id: str | None = None
     ) -> tuple[list[bytes] | None, str | None]:
         """Extract image bytes from the response payload."""
         if "data" not in response:
             return None, "响应中未找到 data 字段"
 
         images = []
+        download_error: str | None = None
         for item in response["data"]:
             if "b64_json" in item:
                 images.append(base64.b64decode(item["b64_json"]))
             elif "url" in item:
                 # Download URL results even though b64_json is requested.
-                async with self._get_session().get(
-                    item["url"], proxy=self.proxy, timeout=self._get_download_timeout()
-                ) as resp:
-                    if resp.status == 200:
-                        images.append(await resp.read())
+                image_url = str(item["url"])
+                download_start = time.time()
+                prefix = self._get_log_prefix(task_id)
+                logger.debug(f"{prefix} 图片下载开始: 地址={safe_log_url(image_url)}")
+                try:
+                    async with self._get_session().get(
+                        image_url,
+                        proxy=self.proxy,
+                        timeout=self._get_timeout(),
+                    ) as resp:
+                        duration = time.time() - download_start
+                        logger.debug(
+                            f"{prefix} 图片下载响应: 状态码={resp.status}, "
+                            f"耗时={duration:.2f}秒, 地址={safe_log_url(image_url)}"
+                        )
+                        if resp.status == 200:
+                            images.append(await resp.read())
+                        else:
+                            download_error = f"HTTP {resp.status}"
+                except Exception as exc:
+                    duration = time.time() - download_start
+                    detail = safe_log_error_body(exc) or type(exc).__name__
+                    download_error = f"{type(exc).__name__}: {exc!r}"
+                    logger.error(
+                        f"{prefix} 图片下载失败: 耗时={duration:.2f}秒, "
+                        f"错误={detail}, 地址={safe_log_url(image_url)}"
+                    )
 
         if not images:
+            if download_error:
+                return (
+                    None,
+                    f"图片下载失败（生成请求已完成，请勿自动重试）: {download_error}",
+                )
             return None, "未找到有效的图片数据"
 
         return images, None
+
+    def _is_retryable_error(self, error: str) -> bool:
+        """Avoid resubmitting a generation after only its result download failed."""
+        if error.startswith("图片下载失败（生成请求已完成"):
+            return False
+        return super()._is_retryable_error(error)

--- a/core/adapters/base.py
+++ b/core/adapters/base.py
@@ -229,6 +229,9 @@ class BaseImageAdapter(abc.ABC):
             exc: Exception or error object.
             label: Human-readable error label.
         """
+        error_text = safe_log_error_body(exc)
+        if not error_text:
+            error_text = type(exc).__name__
         logger.error(
             f"{self._get_log_prefix(request.task_id)} "
             + format_log_event(
@@ -236,7 +239,7 @@ class BaseImageAdapter(abc.ABC):
                 类型=label,
                 **self._format_request_context(request),
                 耗时=format_seconds(duration),
-                错误=safe_log_error_body(exc),
+                错误=error_text,
             )
         )
 

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class _Logger:
+    def debug(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+
+ROOT = Path(__file__).resolve().parents[1]
+astrbot_module = types.ModuleType("astrbot")
+astrbot_api_module = types.ModuleType("astrbot.api")
+astrbot_api_module.logger = _Logger()
+sys.modules.setdefault("astrbot", astrbot_module)
+sys.modules.setdefault("astrbot.api", astrbot_api_module)
+
+plugin_module = types.ModuleType("astrbot_plugin_image_generation")
+plugin_module.__path__ = [str(ROOT)]
+adapter_module = types.ModuleType("astrbot_plugin_image_generation.adapter")
+adapter_module.__path__ = [str(ROOT / "adapter")]
+core_module = types.ModuleType("astrbot_plugin_image_generation.core")
+core_module.__path__ = [str(ROOT / "core")]
+core_adapters_module = types.ModuleType("astrbot_plugin_image_generation.core.adapters")
+core_adapters_module.__path__ = [str(ROOT / "core" / "adapters")]
+core_shared_module = types.ModuleType("astrbot_plugin_image_generation.core.shared")
+core_shared_module.__path__ = [str(ROOT / "core" / "shared")]
+sys.modules.setdefault("astrbot_plugin_image_generation", plugin_module)
+sys.modules.setdefault("astrbot_plugin_image_generation.adapter", adapter_module)
+sys.modules.setdefault("astrbot_plugin_image_generation.core", core_module)
+sys.modules.setdefault(
+    "astrbot_plugin_image_generation.core.adapters", core_adapters_module
+)
+sys.modules.setdefault(
+    "astrbot_plugin_image_generation.core.shared", core_shared_module
+)
+
+OpenAIAdapter = importlib.import_module(
+    "astrbot_plugin_image_generation.adapter.openai_adapter"
+).OpenAIAdapter
+types_module = importlib.import_module(
+    "astrbot_plugin_image_generation.core.shared.types"
+)
+AdapterConfig = types_module.AdapterConfig
+AdapterType = types_module.AdapterType
+GenerationRequest = types_module.GenerationRequest
+
+
+class _StreamContent:
+    def __init__(self, chunks: list[bytes]):
+        self.chunks = chunks
+
+    def iter_any(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self.chunks:
+            yield chunk
+
+
+class _Response:
+    status = 200
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, *, data: bytes = b"image", chunks: list[bytes] | None = None):
+        self.data = data
+        self.content = _StreamContent(chunks or [])
+
+    async def read(self):
+        return self.data
+
+    async def json(self):
+        return {"data": [{"b64_json": base64.b64encode(self.data).decode()}]}
+
+
+class _Context:
+    def __init__(
+        self,
+        response: _Response | None = None,
+        error: Exception | None = None,
+    ):
+        self.response = response
+        self.error = error
+
+    async def __aenter__(self):
+        if self.error:
+            raise self.error
+        return self.response
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Session:
+    closed = False
+
+    def __init__(self, *, post_response: _Response | None = None, get_error=None):
+        self.post_response = post_response or _Response()
+        self.get_error = get_error
+        self.post_kwargs = None
+        self.get_timeout = None
+
+    def post(self, *_args, **kwargs):
+        self.post_kwargs = kwargs
+        return _Context(self.post_response)
+
+    def get(self, *_args, **kwargs):
+        self.get_timeout = kwargs["timeout"]
+        return _Context(_Response(), self.get_error)
+
+
+def _adapter(session: _Session, *, retries: int = 3) -> OpenAIAdapter:
+    config = AdapterConfig(
+        type=AdapterType.OPENAI,
+        name="test",
+        base_url="https://example.test",
+        api_keys=["key"],
+        model="gpt-image-2",
+        timeout=330,
+        max_retry_attempts=retries,
+        extra={"model_family": "gpt-image"},
+    )
+    adapter = OpenAIAdapter(config)
+    adapter._session = session
+    return adapter
+
+
+class OpenAIAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_gpt_image_generation_requests_streaming(self):
+        session = _Session()
+        images, error = await _adapter(session)._generate_once(
+            GenerationRequest(prompt="test")
+        )
+
+        self.assertEqual(images, [b"image"])
+        self.assertIsNone(error)
+        self.assertIs(session.post_kwargs["json"]["stream"], True)
+
+    async def test_sse_completed_event_survives_tcp_chunk_boundaries(self):
+        encoded = base64.b64encode(b"image").decode()
+        event = json.dumps({"type": "image_generation.completed", "b64_json": encoded})
+        wire = f"event: image_generation.completed\ndata: {event}\n\ndata: [DONE]\n\n"
+        chunks = [wire[:17].encode(), wire[17:49].encode(), wire[49:].encode()]
+        response = _Response(chunks=chunks)
+
+        data = await _adapter(_Session())._read_stream_response(response, "task")
+
+        self.assertEqual(data["data"][0]["b64_json"], encoded)
+
+    async def test_url_download_uses_provider_timeout(self):
+        session = _Session()
+        images, error = await _adapter(session)._extract_images(
+            {"data": [{"url": "https://example.test/image.png"}]}, "task"
+        )
+
+        self.assertEqual(images, [b"image"])
+        self.assertIsNone(error)
+        self.assertEqual(session.get_timeout.total, 330)
+
+    async def test_empty_timeout_exception_preserves_its_type(self):
+        session = _Session()
+        session.post = lambda *_args, **_kwargs: _Context(error=asyncio.TimeoutError())
+
+        images, error = await _adapter(session)._generate_once(
+            GenerationRequest(prompt="test")
+        )
+
+        self.assertIsNone(images)
+        self.assertEqual(error, "TimeoutError: TimeoutError()")
+
+    async def test_download_failure_does_not_resubmit_generation(self):
+        session = _Session(get_error=asyncio.TimeoutError())
+        adapter = _adapter(session, retries=3)
+        calls = 0
+
+        async def generated_then_download_failed(_request):
+            nonlocal calls
+            calls += 1
+            return await adapter._extract_images(
+                {"data": [{"url": "https://example.test/image.png"}]}, "task"
+            )
+
+        adapter._generate_once = generated_then_download_failed
+        result = await adapter.generate(GenerationRequest(prompt="test"))
+
+        self.assertEqual(calls, 1)
+        self.assertIsNone(result.images)
+        self.assertIn("TimeoutError", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- request GPT Image text generations with `stream: true` and parse OpenAI-compatible SSE completion/error events
- accept completion events split across transport chunks and preserve JSON fallback behavior
- use the configured provider timeout when downloading URL-based completed results
- prevent automatic generation resubmission after only the completed result download fails
- preserve exception type names when exceptions such as `TimeoutError()` stringify to an empty string

## Why

In v1.6.0, a long non-streaming image request can be terminated by an intermediate approximately 60-second idle timeout even while the upstream continues generating. Enabling image SSE gives compatible gateways a way to keep the downstream request alive.

A real completion then exposed a second issue: the gateway returned a completed event containing `url` rather than `b64_json`. The generation response arrived successfully after 52.39 seconds, but the follow-up URL fetch failed exactly around the fixed 30-second `DEFAULT_DOWNLOAD_TIMEOUT`. That made a successfully generated image appear as a generation failure.

The generic retry loop can subsequently resubmit the paid generation. The adapter now marks a post-completion download failure as non-retryable while returning the concrete download error.

## Compatibility

- streaming is enabled only for GPT Image text generation requests
- DALL-E requests keep their existing JSON path
- non-SSE responses continue through `_read_response_json()`
- both completed `b64_json` and `url` results are supported
- image edits retain their existing multipart behavior

## Tests

```text
python -m unittest discover -s tests -v

Ran 5 tests
OK
```

The tests cover:

- GPT Image generation includes `stream: true`
- SSE completion events survive TCP chunk boundaries
- URL result downloads inherit the 330-second provider timeout
- empty `TimeoutError()` details preserve the exception type
- a post-completion download failure does not resubmit generation even with three configured attempts

Fixes #54