### PR TITLE
fix: OpenAI & Grok 接口图片上传格式bug

### DIFF
--- a/adapter/grok_adapter.py
+++ b/adapter/grok_adapter.py
@@ -4,6 +4,8 @@ import base64
 import time
 from typing import Any
 
+import aiohttp
+
 from ..core.adapters.base import BaseImageAdapter
 from ..core.shared.constants import UNSPECIFIED_OPTION
 from ..core.shared.logging import safe_log_error_body
@@ -25,7 +27,6 @@ class GrokAdapter(BaseImageAdapter):
         """Execute one image generation request."""
         start_time = time.time()
 
-        payload = self._build_payload(request)
         session = self._get_session()
 
         if request.images:
@@ -39,20 +40,50 @@ class GrokAdapter(BaseImageAdapter):
             # main.py strips /v1, so add it here consistently.
             url = f"{self.base_url.rstrip('/')}/v1{end_point}"
 
-        headers = {
-            "Authorization": f"Bearer {self._get_current_api_key()}",
-            "Content-Type": "application/json",
-        }
-        self._log_request_overview(request, url, payload=payload)
-        self._log_debug_json("请求", payload, request.task_id)
+        headers = {"Authorization": f"Bearer {self._get_current_api_key()}"}
+        if request.images:
+            form = aiohttp.FormData()
+            form.add_field("model", self.model or "grok-imagine-image")
+            form.add_field("prompt", request.prompt)
+            form.add_field("response_format", "b64_json")
+            if ratio := self._get_aspect_ratio(request):
+                form.add_field("aspect_ratio", ratio)
+            if resolution := self._get_resolution(request):
+                form.add_field("resolution", resolution)
+            for index, image in enumerate(request.images, start=1):
+                form.add_field(
+                    "image",
+                    image.data,
+                    content_type=image.mime_type,
+                    filename=self._image_filename(image.mime_type, index),
+                )
+            kwargs: dict[str, Any] = {"data": form}
+            self._log_request_overview(
+                request,
+                url,
+                form_fields=[
+                    "model",
+                    "prompt",
+                    "response_format",
+                    "aspect_ratio",
+                    "resolution",
+                    "image",
+                ],
+            )
+        else:
+            payload = self._build_payload(request)
+            headers["Content-Type"] = "application/json"
+            kwargs = {"json": payload}
+            self._log_request_overview(request, url, payload=payload)
+            self._log_debug_json("请求", payload, request.task_id)
 
         try:
             async with session.post(
                 url,
-                json=payload,
                 headers=headers,
                 proxy=self.proxy,
                 timeout=self._get_timeout(),
+                **kwargs,
             ) as resp:
                 duration = time.time() - start_time
                 self._log_response_status(request, resp.status, duration)
@@ -93,17 +124,8 @@ class GrokAdapter(BaseImageAdapter):
         ]
         accept_resolution = ["1k", "2k"]
 
-        ratio = None
-        if request.aspect_ratio and request.aspect_ratio in accept_ratio:
-            ratio = request.aspect_ratio
-
-        resolution = None
-        if (
-            request.resolution
-            and request.resolution != UNSPECIFIED_OPTION
-            and request.resolution.lower() in accept_resolution
-        ):
-            resolution = request.resolution.lower()
+        ratio = self._get_aspect_ratio(request, accept_ratio)
+        resolution = self._get_resolution(request, accept_resolution)
 
         images_ref = []
         for image in request.images:
@@ -129,6 +151,40 @@ class GrokAdapter(BaseImageAdapter):
             payload.update({"images": images_ref})
 
         return payload
+
+    def _get_aspect_ratio(
+        self,
+        request: GenerationRequest,
+        accepted: list[str] | None = None,
+    ) -> str | None:
+        """Validate and return the requested Grok aspect ratio."""
+        accepted = accepted or [
+            "auto", "1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3",
+            "1:2", "2:1", "19.5:9", "9:19.5", "20:9", "9:20",
+        ]
+        return request.aspect_ratio if request.aspect_ratio in accepted else None
+
+    def _get_resolution(
+        self,
+        request: GenerationRequest,
+        accepted: list[str] | None = None,
+    ) -> str | None:
+        """Validate and return the requested Grok resolution."""
+        accepted = accepted or ["1k", "2k"]
+        value = (request.resolution or "").lower()
+        return value if value != UNSPECIFIED_OPTION and value in accepted else None
+
+    def _image_filename(self, mime_type: str, index: int) -> str:
+        """Return a filename whose extension matches the uploaded image bytes."""
+        extension = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+            "image/gif": ".gif",
+            "image/heic": ".heic",
+            "image/heif": ".heif",
+        }.get((mime_type or "").lower(), ".png")
+        return f"reference_{index}{extension}"
 
     async def _extract_images(
         self, response: dict

--- a/adapter/openai_adapter.py
+++ b/adapter/openai_adapter.py
@@ -32,6 +32,18 @@ class OpenAIAdapter(BaseImageAdapter):
         # auto: infer the family from the model name.
         return self.model is not None and "gpt-image" in self.model
 
+    def _image_filename(self, mime_type: str, index: int) -> str:
+        """Return a filename whose extension matches the uploaded image bytes."""
+        extension = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+            "image/gif": ".gif",
+            "image/heic": ".heic",
+            "image/heif": ".heif",
+        }.get((mime_type or "").lower(), ".png")
+        return f"reference_{index}{extension}"
+
     async def _generate_once(
         self, request: GenerationRequest
     ) -> tuple[list[bytes] | None, str | None]:
@@ -59,12 +71,12 @@ class OpenAIAdapter(BaseImageAdapter):
                 request.aspect_ratio, gpt_model=True
             ):
                 form.add_field("size", size)
-            for img in request.images:
+            for index, img in enumerate(request.images, start=1):
                 form.add_field(
                     "image[]",
                     img.data,
                     content_type=img.mime_type,
-                    filename="image",
+                    filename=self._image_filename(img.mime_type, index),
                 )
             kwargs: dict = {"data": form}
         else:


### PR DESCRIPTION
  ## 修复内容

  修复 OpenAI 和 Grok 适配器在图生图请求中的图片上传格式问题。

  ### OpenAI

  参考图此前使用无扩展名的 `filename="image"` 上传。部分兼容接口会根据文件名推断文件类型，导致 JPEG 内容被识别为 PNG，从而报错：

  > image 字段的文件类型是 png，但是实际传入 jpeg

  现在根据真实 MIME 设置对应扩展名，例如：

  - `image/jpeg` -> `reference_1.jpg`
  - `image/png` -> `reference_2.png`

  ### Grok

  参考图此前通过 JSON 请求体的 `images` 字段发送，但图片编辑接口要求使用 `multipart/form-data`，并通过 `image` 文件字段传入图片，因此接口报错：

  > image is required

  现在 Grok 图生图请求改为 multipart 上传，并保留模型、提示词、响应格式、宽高比和分辨率参数。