### PR TITLE
fix: harden OpenAI image result transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ LLM 生图工具支持 `preset`、`persona`、`aspect_ratio`、`resolution`、`i
 - 火山方舟的可用模型列表需要按控制台实际 Model ID 或 Endpoint ID 配置。
 - 配置 `jimeng2api` 后，插件会在启动时和每天日期变更后自动领取积分；仅直接连接即梦逆向服务时有效。
 - 即梦逆向图生图使用 `/v1/images/compositions`，使用中转可能会导致图生图失败。
+- OpenAI Images 文生图默认使用流式响应。中转缓冲或截断大型完成事件时可关闭“启用流式响应”，并可把 GPT Image 输出格式设为 JPEG 以缩小 Base64 响应。
 - Codex Responses 接口支持在单次 HTTP 请求内返回最终图片的文生图和图生图；参考图会作为多模态 `input_image` data URL 发送，但宽高比和分辨率会被忽略。若日志在约 150 秒显示 `Server disconnected`、后续任务仍成功，通常是服务端或中间网络主动断开后触发了插件重试，而不是本插件的请求超时；详见 [Codex Responses 接口配置](docs/codex-responses.md)。
 - 自定义 HTTP 接口为高级功能，建议先阅读 [自定义 HTTP 接口配置](docs/custom-http.md)。
 - 开启调试请求日志或详细错误信息时，插件会做脱敏和摘要处理，但仍建议避免在公共环境暴露日志。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -292,6 +292,23 @@
               "dall-e"
             ],
             "default": "auto"
+          },
+          "enable_streaming": {
+            "description": "启用流式响应",
+            "hint": "默认开启并使用 OpenAI Images SSE。部分中转会缓冲或截断最终图片事件，遇到超时或响应体不完整时可关闭。",
+            "type": "bool",
+            "default": true
+          },
+          "output_format": {
+            "description": "GPT Image 输出格式",
+            "hint": "PNG 保留无损质量；JPEG 响应更小，适合会截断大型 Base64 响应的中转接口。仅影响 GPT Image 系列。",
+            "type": "string",
+            "options": [
+              "png",
+              "jpeg",
+              "webp"
+            ],
+            "default": "png"
           }
         }
       },

--- a/adapter/openai_adapter.py
+++ b/adapter/openai_adapter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import base64
+import json
 import time
 from typing import Any
 
@@ -10,7 +12,7 @@ from astrbot.api import logger
 
 from ..core.adapters.base import BaseImageAdapter
 from ..core.shared.constants import UNSPECIFIED_OPTION
-from ..core.shared.logging import safe_log_error_body
+from ..core.shared.logging import safe_log_error_body, safe_log_url
 from ..core.shared.types import GenerationRequest, ImageCapability
 
 
@@ -70,6 +72,10 @@ class OpenAIAdapter(BaseImageAdapter):
             url = f"{base}/v1/images/generations"
             headers["Content-Type"] = "application/json"
             payload = self._build_payload(request)
+            if is_gpt:
+                payload["stream"] = bool(
+                    self.config.extra.get("enable_streaming", True)
+                )
             kwargs = {"json": payload}
             self._log_request_overview(request, url, payload=payload)
             self._log_debug_json("请求", payload, request.task_id)
@@ -98,12 +104,88 @@ class OpenAIAdapter(BaseImageAdapter):
                         resp.status,
                         error_text,
                     )
-                data = await self._read_response_json(resp, request.task_id)
-                return await self._extract_images(data)
+                if (
+                    is_gpt
+                    and "text/event-stream"
+                    in resp.headers.get("Content-Type", "").lower()
+                ):
+                    data = await self._read_stream_response(resp, request.task_id)
+                else:
+                    data = await self._read_response_json(resp, request.task_id)
+                return await self._extract_images(data, request.task_id)
         except Exception as e:
             duration = time.time() - start_time
             self._log_request_exception(request, duration, e)
-            return None, safe_log_error_body(e)
+            error_detail = safe_log_error_body(e)
+            if not error_detail:
+                error_detail = f"{type(e).__name__}: {e!r}"
+            return None, error_detail
+
+    async def _read_stream_response(
+        self, response: aiohttp.ClientResponse, task_id: str | None
+    ) -> dict[str, Any]:
+        """Collect completed image events from an OpenAI-compatible SSE response."""
+        images: list[dict[str, Any]] = []
+        buffer = ""
+        data_lines: list[str] = []
+        stream_error: str | None = None
+
+        def collect_event(payload_text: str) -> None:
+            nonlocal stream_error
+            if not payload_text or payload_text == "[DONE]":
+                return
+            try:
+                event = json.loads(payload_text)
+            except json.JSONDecodeError:
+                return
+            if not isinstance(event, dict):
+                return
+
+            event_type = str(event.get("type", "")).strip().lower()
+            if event_type in {"error", "upstream_error"} or event.get("error"):
+                error = event.get("error")
+                if isinstance(error, dict):
+                    stream_error = str(error.get("message") or error)
+                else:
+                    stream_error = str(event.get("message") or error)
+            elif isinstance(event.get("data"), list):
+                images.extend(item for item in event["data"] if isinstance(item, dict))
+            elif event_type in {
+                "image_generation.completed",
+                "image_edit.completed",
+            }:
+                images.append(event)
+
+        async for chunk in response.content.iter_any():
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.rstrip("\r")
+                if line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+                if line or not data_lines:
+                    continue
+
+                collect_event("\n".join(data_lines).strip())
+                data_lines.clear()
+
+        if buffer.rstrip("\r").startswith("data:"):
+            data_lines.append(buffer.rstrip("\r")[5:].lstrip())
+        if data_lines:
+            collect_event("\n".join(data_lines).strip())
+
+        if stream_error:
+            raise RuntimeError(f"Image stream error: {stream_error}")
+
+        self._log_debug_json(
+            "SSE response",
+            {
+                "event_count": len(images),
+                "image_fields": [list(item) for item in images],
+            },
+            task_id,
+        )
+        return {"data": images}
 
     def _build_payload(self, request: GenerationRequest) -> dict:
         """Build the request payload."""
@@ -117,8 +199,15 @@ class OpenAIAdapter(BaseImageAdapter):
         if size := self._map_aspect_ratio_to_size(request.aspect_ratio, gpt_model=gpt):
             payload["size"] = size
         # OpenAI models do not support the plugin resolution setting; quality is separate.
-        if not gpt:
-            # GPT Image models always return b64_json and do not support response_format.
+        if gpt:
+            output_format = str(
+                self.config.extra.get("output_format") or "png"
+            ).lower()
+            payload["output_format"] = (
+                output_format if output_format in {"png", "jpeg", "webp"} else "png"
+            )
+        else:
+            # Keep DALL-E results self-contained for local persistence.
             payload["response_format"] = "b64_json"
 
         return payload
@@ -163,25 +252,68 @@ class OpenAIAdapter(BaseImageAdapter):
         return mapping.get(aspect_ratio)
 
     async def _extract_images(
-        self, response: dict
+        self, response: dict, task_id: str | None = None
     ) -> tuple[list[bytes] | None, str | None]:
         """Extract image bytes from the response payload."""
         if "data" not in response:
             return None, "响应中未找到 data 字段"
 
         images = []
+        download_error: str | None = None
         for item in response["data"]:
             if "b64_json" in item:
                 images.append(base64.b64decode(item["b64_json"]))
             elif "url" in item:
                 # Download URL results even though b64_json is requested.
-                async with self._get_session().get(
-                    item["url"], proxy=self.proxy, timeout=self._get_download_timeout()
-                ) as resp:
-                    if resp.status == 200:
-                        images.append(await resp.read())
+                image_url = str(item["url"])
+                prefix = self._get_log_prefix(task_id)
+                for attempt in range(1, 4):
+                    download_start = time.time()
+                    logger.debug(
+                        f"{prefix} 图片下载开始: 尝试={attempt}/3, "
+                        f"地址={safe_log_url(image_url)}"
+                    )
+                    try:
+                        async with self._get_session().get(
+                            image_url,
+                            proxy=self.proxy,
+                            timeout=self._get_timeout(),
+                        ) as resp:
+                            duration = time.time() - download_start
+                            logger.debug(
+                                f"{prefix} 图片下载响应: 状态码={resp.status}, "
+                                f"尝试={attempt}/3, 耗时={duration:.2f}秒, "
+                                f"地址={safe_log_url(image_url)}"
+                            )
+                            if resp.status == 200:
+                                images.append(await resp.read())
+                                download_error = None
+                                break
+                            download_error = f"HTTP {resp.status}"
+                    except Exception as exc:
+                        duration = time.time() - download_start
+                        detail = safe_log_error_body(exc) or type(exc).__name__
+                        download_error = f"{type(exc).__name__}: {exc!r}"
+                        logger.warning(
+                            f"{prefix} 图片下载失败: 尝试={attempt}/3, "
+                            f"耗时={duration:.2f}秒, 错误={detail}, "
+                            f"地址={safe_log_url(image_url)}"
+                        )
+                    if attempt < 3:
+                        await asyncio.sleep(2 ** (attempt - 1))
 
         if not images:
+            if download_error:
+                return (
+                    None,
+                    f"图片下载失败（生成请求已完成，请勿自动重试）: {download_error}",
+                )
             return None, "未找到有效的图片数据"
 
         return images, None
+
+    def _is_retryable_error(self, error: str) -> bool:
+        """Avoid resubmitting a generation after only its result download failed."""
+        if error.startswith("图片下载失败（生成请求已完成"):
+            return False
+        return super()._is_retryable_error(error)

--- a/core/adapters/base.py
+++ b/core/adapters/base.py
@@ -229,6 +229,9 @@ class BaseImageAdapter(abc.ABC):
             exc: Exception or error object.
             label: Human-readable error label.
         """
+        error_text = safe_log_error_body(exc)
+        if not error_text:
+            error_text = type(exc).__name__
         logger.error(
             f"{self._get_log_prefix(request.task_id)} "
             + format_log_event(
@@ -236,7 +239,7 @@ class BaseImageAdapter(abc.ABC):
                 类型=label,
                 **self._format_request_context(request),
                 耗时=format_seconds(duration),
-                错误=safe_log_error_body(exc),
+                错误=error_text,
             )
         )
 

--- a/core/config/provider_parser.py
+++ b/core/config/provider_parser.py
@@ -35,7 +35,11 @@ ADAPTER_EXTRA_DEFAULTS: dict[AdapterType, dict[str, Any]] = {
         "prompt_prefix": "Generate an image: ",
         "modalities": ["image", "text"],
     },
-    AdapterType.OPENAI: {"model_family": "auto"},
+    AdapterType.OPENAI: {
+        "model_family": "auto",
+        "enable_streaming": True,
+        "output_format": "png",
+    },
     AdapterType.AGNES_AI: {"response_format": "base64"},
 }
 LOG = log_prefix("Config")


### PR DESCRIPTION
## Summary

- handle OpenAI Images SSE completion events and stop reading as soon as the final image event arrives
- add a per-provider `enable_streaming` switch while keeping streaming enabled by default for backward compatibility
- add configurable GPT Image `output_format` so relays can request a smaller JPEG/WebP payload when supported
- retry downloads from the same returned image URL up to three times without resubmitting generation
- keep post-generation download failures non-retryable at the generation layer to avoid duplicate charges

## Why

An OpenAI-compatible relay can finish and bill the upstream image generation while AstrBot still receives no persistable image bytes. The observed failure boundary is after generation and before local persistence, with three likely interruption points:

1. **SSE completion frame**: GPT Image places the final Base64 payload in one large `image_generation.completed` event. Relay buffering, an incomplete chunk terminator, or an early connection close can leave the client waiting until timeout or raise a transfer-length error.
2. **Non-streaming JSON response**: disabling SSE moves the same large Base64 payload into a chunked JSON response. Relays that truncate large downstream bodies can close before the JSON is complete.
3. **Returned image URL**: some compatible endpoints return a temporary URL. The generation has already completed at this point, while the subsequent CDN/object-storage response may end before the declared `Content-Length` is received.

The new controls let each provider choose the transport that its relay handles reliably. The URL retry path reuses only the returned URL, so a transient download failure does not create another image-generation request or another charge.

## Compatibility

- streaming remains enabled by default
- DALL-E request behavior is preserved
- GPT Image output format defaults to PNG
- existing configurations require no migration

## Verification

- `ruff check adapter/openai_adapter.py core/adapters/base.py core/config/provider_parser.py`
- `_conf_schema.json` parsed successfully
- live smoke verification on the affected provider completed with one generation attempt and a decodable saved image

This PR contains no test case, fixture, prompt, generated image, task log, or design-document changes.