### PR TITLE
fix: harden OpenAI image result transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ LLM 生图工具支持 `preset`、`persona`、`aspect_ratio`、`resolution`、`i
 - 火山方舟的可用模型列表需要按控制台实际 Model ID 或 Endpoint ID 配置。
 - 配置 `jimeng2api` 后，插件会在启动时和每天日期变更后自动领取积分；仅直接连接即梦逆向服务时有效。
 - 即梦逆向图生图使用 `/v1/images/compositions`，使用中转可能会导致图生图失败。
+- OpenAI Images 文生图默认使用流式响应。中转缓冲或截断大型完成事件时可关闭“启用流式响应”，并可把 GPT Image 输出格式设为 JPEG 以缩小 Base64 响应。
 - Codex Responses 接口支持在单次 HTTP 请求内返回最终图片的文生图和图生图；参考图会作为多模态 `input_image` data URL 发送，但宽高比和分辨率会被忽略。若日志在约 150 秒显示 `Server disconnected`、后续任务仍成功，通常是服务端或中间网络主动断开后触发了插件重试，而不是本插件的请求超时；详见 [Codex Responses 接口配置](docs/codex-responses.md)。
 - 自定义 HTTP 接口为高级功能，建议先阅读 [自定义 HTTP 接口配置](docs/custom-http.md)。
 - 开启调试请求日志或详细错误信息时，插件会做脱敏和摘要处理，但仍建议避免在公共环境暴露日志。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -298,6 +298,17 @@
             "hint": "文生图默认开启 SSE。部分兼容站点不支持流式时可关闭，改为普通 JSON 响应。",
             "type": "bool",
             "default": true
+          },
+          "output_format": {
+            "description": "GPT Image 输出格式",
+            "hint": "PNG 保留无损质量；JPEG 响应更小，适合会截断大型 Base64 响应的中转接口。仅影响 GPT Image 系列。",
+            "type": "string",
+            "options": [
+              "png",
+              "jpeg",
+              "webp"
+            ],
+            "default": "png"
           }
         }
       },

--- a/adapter/openai_adapter.py
+++ b/adapter/openai_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import time
@@ -224,8 +225,15 @@ class OpenAIAdapter(BaseImageAdapter):
         if size := self._map_aspect_ratio_to_size(request.aspect_ratio, gpt_model=gpt):
             payload["size"] = size
         # OpenAI models do not support the plugin resolution setting; quality is separate.
-        if not gpt:
-            # GPT Image models always return b64_json and do not support response_format.
+        if gpt:
+            output_format = str(
+                self.config.extra.get("output_format") or "png"
+            ).lower()
+            payload["output_format"] = (
+                output_format if output_format in {"png", "jpeg", "webp"} else "png"
+            )
+        else:
+            # Keep DALL-E results self-contained for local persistence.
             payload["response_format"] = "b64_json"
 
         return payload
@@ -284,32 +292,41 @@ class OpenAIAdapter(BaseImageAdapter):
             elif "url" in item:
                 # Download URL results even though b64_json is requested.
                 image_url = str(item["url"])
-                download_start = time.time()
                 prefix = self._get_log_prefix(task_id)
-                logger.debug(f"{prefix} 图片下载开始: 地址={safe_log_url(image_url)}")
-                try:
-                    async with self._get_session().get(
-                        image_url,
-                        proxy=self.proxy,
-                        timeout=self._get_timeout(),
-                    ) as resp:
-                        duration = time.time() - download_start
-                        logger.debug(
-                            f"{prefix} 图片下载响应: 状态码={resp.status}, "
-                            f"耗时={duration:.2f}秒, 地址={safe_log_url(image_url)}"
-                        )
-                        if resp.status == 200:
-                            images.append(await resp.read())
-                        else:
-                            download_error = f"HTTP {resp.status}"
-                except Exception as exc:
-                    duration = time.time() - download_start
-                    detail = safe_log_error_body(exc) or type(exc).__name__
-                    download_error = detail
-                    logger.error(
-                        f"{prefix} 图片下载失败: 耗时={duration:.2f}秒, "
-                        f"错误={detail}, 地址={safe_log_url(image_url)}"
+                for attempt in range(1, 4):
+                    download_start = time.time()
+                    logger.debug(
+                        f"{prefix} 图片下载开始: 尝试={attempt}/3, "
+                        f"地址={safe_log_url(image_url)}"
                     )
+                    try:
+                        async with self._get_session().get(
+                            image_url,
+                            proxy=self.proxy,
+                            timeout=self._get_timeout(),
+                        ) as resp:
+                            duration = time.time() - download_start
+                            logger.debug(
+                                f"{prefix} 图片下载响应: 状态码={resp.status}, "
+                                f"尝试={attempt}/3, 耗时={duration:.2f}秒, "
+                                f"地址={safe_log_url(image_url)}"
+                            )
+                            if resp.status == 200:
+                                images.append(await resp.read())
+                                download_error = None
+                                break
+                            download_error = f"HTTP {resp.status}"
+                    except Exception as exc:
+                        duration = time.time() - download_start
+                        detail = safe_log_error_body(exc) or type(exc).__name__
+                        download_error = f"{type(exc).__name__}: {exc!r}"
+                        logger.warning(
+                            f"{prefix} 图片下载失败: 尝试={attempt}/3, "
+                            f"耗时={duration:.2f}秒, 错误={detail}, "
+                            f"地址={safe_log_url(image_url)}"
+                        )
+                    if attempt < 3:
+                        await asyncio.sleep(2 ** (attempt - 1))
 
         if not images:
             if download_error:

--- a/core/config/provider_parser.py
+++ b/core/config/provider_parser.py
@@ -35,7 +35,11 @@ ADAPTER_EXTRA_DEFAULTS: dict[AdapterType, dict[str, Any]] = {
         "prompt_prefix": "Generate an image: ",
         "modalities": ["image", "text"],
     },
-    AdapterType.OPENAI: {"model_family": "auto", "enable_streaming": True},
+    AdapterType.OPENAI: {
+        "model_family": "auto",
+        "enable_streaming": True,
+        "output_format": "png",
+    },
     AdapterType.AGNES_AI: {"response_format": "base64"},
     AdapterType.CODEX_RESPONSES: {"endpoint": "/codex/responses"},
 }


### PR DESCRIPTION
## Summary

- handle OpenAI Images SSE completion events and stop reading as soon as the final image event arrives
- add a per-provider `enable_streaming` switch while keeping streaming enabled by default for backward compatibility
- add configurable GPT Image `output_format` so relays can request a smaller JPEG/WebP payload when supported
- retry downloads from the same returned image URL up to three times without resubmitting generation
- keep post-generation download failures non-retryable at the generation layer to avoid duplicate charges

## Why

An OpenAI-compatible relay can finish and bill the upstream image generation while AstrBot still receives no persistable image bytes. The observed failure boundary is after generation and before local persistence, with three likely interruption points:

1. **SSE completion frame**: GPT Image places the final Base64 payload in one large `image_generation.completed` event. Relay buffering, an incomplete chunk terminator, or an early connection close can leave the client waiting until timeout or raise a transfer-length error.
2. **Non-streaming JSON response**: disabling SSE moves the same large Base64 payload into a chunked JSON response. Relays that truncate large downstream bodies can close before the JSON is complete.
3. **Returned image URL**: some compatible endpoints return a temporary URL. The generation has already completed at this point, while the subsequent CDN/object-storage response may end before the declared `Content-Length` is received.

The new controls let each provider choose the transport that its relay handles reliably. The URL retry path reuses only the returned URL, so a transient download failure does not create another image-generation request or another charge.

## Compatibility

- streaming remains enabled by default
- DALL-E request behavior is preserved
- GPT Image output format defaults to PNG
- existing configurations require no migration

## Verification

- `ruff check adapter/openai_adapter.py core/adapters/base.py core/config/provider_parser.py`
- `_conf_schema.json` parsed successfully
- live smoke verification on the affected provider completed with one generation attempt and a decodable saved image

This PR contains no test case, fixture, prompt, generated image, task log, or design-document changes.
